### PR TITLE
Bluetooth-test and Message structure improvements

### DIFF
--- a/fanClub/AndroidManifest.xml
+++ b/fanClub/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="8"
+        android:minSdkVersion="10"
         android:targetSdkVersion="17" />
 
     <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/fanClub/res/layout/activity_fan.xml
+++ b/fanClub/res/layout/activity_fan.xml
@@ -4,11 +4,22 @@
     android:layout_height="match_parent"
     tools:context=".FanActivity" >
 
-    <TextView
+    <Button
+        android:id="@+id/btn_let_me_in"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
-        android:text="@string/welcome_text" />
+        android:text="Let Me In" />
+
+    <Button
+        android:id="@+id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/button0"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="26dp"
+        android:text="You Rock!" />
+
 
 </RelativeLayout>

--- a/fanClub/res/layout/activity_host.xml
+++ b/fanClub/res/layout/activity_host.xml
@@ -19,6 +19,6 @@
         android:layout_below="@+id/button0"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="26dp"
-        android:text="Hello, Reid!" />
+        android:text="Hello, Cleveland!" />
 
 </RelativeLayout>

--- a/fanClub/res/values/strings.xml
+++ b/fanClub/res/values/strings.xml
@@ -9,5 +9,7 @@
     <string name="title_activity_host">HostActivity</string>
     <string name="create_network">Create</string>
     <string name="join_network">Join</string>
+    <string name="enable_bluetooth">Enabling Bluetooth...</string>
+    <string name="finding_new_fans">Finding new fans...</string>
 
 </resources>

--- a/fanClub/src/com/lastcrusade/fanclub/AcceptThread.java
+++ b/fanClub/src/com/lastcrusade/fanclub/AcceptThread.java
@@ -3,54 +3,38 @@ package com.lastcrusade.fanclub;
 import java.io.IOException;
 import java.util.UUID;
 
-import com.lastcrusade.fanclub.util.Toaster;
-
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
 import android.content.Context;
+import android.os.AsyncTask;
 import android.util.Log;
 
-public class AcceptThread extends Thread {
+/**
+ * Listen for incoming connections for a specific service (identified by the UUID).
+ * 
+ * This runs on the discoverable device, to accept connections from discovering devices.
+ * 
+ * @author Jesse Rosalia
+ *
+ */
+public abstract class AcceptThread extends AsyncTask<Void, Void, BluetoothSocket> {
     private final String TAG = "AcceptThread";
     private final BluetoothServerSocket mmServerSocket;
     private String HOST_NAME = "Patty Placeholder's party";
     
-    public AcceptThread(Context context, BluetoothAdapter mBluetoothAdapter) {
+    public AcceptThread(Context context, BluetoothAdapter adapter) throws UnableToCreateSocketException {
         // Use a temporary object that is later assigned to mmServerSocket,
         // because mmServerSocket is final
         BluetoothServerSocket tmp = null;
         try {
             // MY_UUID is the app's UUID string, also used by the client code
-            tmp = mBluetoothAdapter.listenUsingRfcommWithServiceRecord(
+            //TODO: for scaling to large number of users, we may have to use different UUIDs
+            mmServerSocket = adapter.listenUsingRfcommWithServiceRecord(
                     HOST_NAME,
                     UUID.fromString(context.getString(R.string.app_uuid)));
         } catch (IOException e) {
-        }
-        mmServerSocket = tmp;
-    }
- 
-    public void run() {
-        BluetoothSocket socket = null;
-        // Keep listening until exception occurs or a socket is returned
-        while (true) {
-            try {
-                socket = mmServerSocket.accept();
-            } catch (IOException e) {
-                break;
-            }
-            // If a connection was accepted
-            if (socket != null) {
-                // Do work to manage the connection (in a separate thread)
-                Log.i(TAG, "connection accepted");
-                try {
-                    socket.close();
-                } catch (IOException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-                break;
-            }
+            throw new UnableToCreateSocketException(e);
         }
     }
  
@@ -60,4 +44,26 @@ public class AcceptThread extends Thread {
             mmServerSocket.close();
         } catch (IOException e) { }
     }
+
+    @Override
+    protected BluetoothSocket doInBackground(Void... params) {
+        BluetoothSocket socket = null;
+        try {
+            socket = mmServerSocket.accept();
+            Log.i(TAG, "Connection accepted");
+        } catch (IOException e) {
+            Log.e(TAG, "Unable to accept connection", e);
+        }
+        return socket;
+    }
+
+    @Override
+    protected void onPostExecute(BluetoothSocket result) {
+        if (result != null) {
+            onAccepted(result);
+        }
+    }
+
+    protected abstract void onAccepted(BluetoothSocket socket);
+    
 }

--- a/fanClub/src/com/lastcrusade/fanclub/BluetoothNotSupportedException.java
+++ b/fanClub/src/com/lastcrusade/fanclub/BluetoothNotSupportedException.java
@@ -1,0 +1,5 @@
+package com.lastcrusade.fanclub;
+
+public class BluetoothNotSupportedException extends Exception {
+
+}

--- a/fanClub/src/com/lastcrusade/fanclub/ConnectThread.java
+++ b/fanClub/src/com/lastcrusade/fanclub/ConnectThread.java
@@ -20,8 +20,8 @@ import android.util.Log;
 public abstract class ConnectThread extends AsyncTask<Void, Void, BluetoothSocket> {
     private final String TAG = "ConnectThread";
     private final BluetoothDevice mmDevice;
-    private final BluetoothSocket mmSocket;
     private final Context mmContext;
+    private BluetoothSocket mmSocket;
 
     public ConnectThread(Context context, BluetoothDevice device) throws UnableToCreateSocketException {
         mmContext = context;
@@ -66,6 +66,7 @@ public abstract class ConnectThread extends AsyncTask<Void, Void, BluetoothSocke
     public void cancel() {
         try {
             mmSocket.close();
+            mmSocket = null;
         } catch (IOException e) {
             //Nothing to do..fall thru gracefully
         }

--- a/fanClub/src/com/lastcrusade/fanclub/ConnectThread.java
+++ b/fanClub/src/com/lastcrusade/fanclub/ConnectThread.java
@@ -7,47 +7,50 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
 import android.content.Context;
 import android.os.AsyncTask;
+import android.util.Log;
 
 /**
  * This thread is responsible for establishing a connection to a discovered device.
+ * 
+ * This will run on the discovering device, to connect to one and only one discoverable device.  This means
+ * that connecting to multiple devices will require multiple instances of this thread.
  * 
  * @author Jesse Rosalia
  */
 public abstract class ConnectThread extends AsyncTask<Void, Void, BluetoothSocket> {
     private final String TAG = "ConnectThread";
     private final BluetoothDevice mmDevice;
-    private Context mmContext;
+    private final BluetoothSocket mmSocket;
+    private final Context mmContext;
 
-    public ConnectThread(Context context, BluetoothDevice device) throws IOException {
+    public ConnectThread(Context context, BluetoothDevice device) throws UnableToCreateSocketException {
         mmContext = context;
         mmDevice = device;
+        // Get a BluetoothSocket to connect with the given BluetoothDevice
+        // MY_UUID is the app's UUID string, also used by the server code
+        UUID uuid = UUID.fromString(mmContext.getString(R.string.app_uuid));
+        try {
+            mmSocket = mmDevice.createRfcommSocketToServiceRecord(uuid);
+        } catch (IOException e) {
+            //if for some reason the socket cannot be created, throw an exception
+            throw new UnableToCreateSocketException(e);
+        }
     }
     
     @Override
     protected BluetoothSocket doInBackground(Void... params) {
-        BluetoothSocket socket = null;
         try {
-            // Get a BluetoothSocket to connect with the given BluetoothDevice
-            // MY_UUID is the app's UUID string, also used by the server code
-            UUID uuid = UUID.fromString(mmContext.getString(R.string.app_uuid));
-            // Use a temporary object that is later assigned to mmSocket,
-            // because mmSocket is final
-            socket = mmDevice.createRfcommSocketToServiceRecord(uuid);
             // Connect the device through the socket. This will block
             // until it succeeds or throws an exception
-            socket.connect();
-        } catch (IOException connectException) {
+            mmSocket.connect();
+            Log.i(TAG, "Socket connected");
+        } catch (IOException e) {
             // Unable to connect; close the socket and get out
-            try {
-                if (socket != null) {
-                    socket.close();
-                }
-            } catch (IOException closeException) {
-            }
-            return null;
+            Log.e(TAG, "Unable to connect socket", e);
+            cancel();
         }
 
-        return socket;
+        return mmSocket;
     }
 
     @Override
@@ -59,11 +62,12 @@ public abstract class ConnectThread extends AsyncTask<Void, Void, BluetoothSocke
 
     protected abstract void onConnected(BluetoothSocket socket);
     
-//    /** Will cancel an in-progress connection, and close the socket */
-//    public void cancel() {
-//        try {
-//            mmSocket.close();
-//        } catch (IOException e) {
-//        }
-//    }
+    /** Will cancel an in-progress connection, and close the socket */
+    public void cancel() {
+        try {
+            mmSocket.close();
+        } catch (IOException e) {
+            //Nothing to do..fall thru gracefully
+        }
+    }
 }

--- a/fanClub/src/com/lastcrusade/fanclub/FanActivity.java
+++ b/fanClub/src/com/lastcrusade/fanclub/FanActivity.java
@@ -23,9 +23,6 @@ import com.lastcrusade.fanclub.util.Toaster;
 
 public class FanActivity extends Activity {
 
-    private StringBuilder message = new StringBuilder();
-    private Object msgMutex = new Object();
-
     private final String TAG = "FanActivity";
     private BluetoothServerSocket mmServerSocket;
     private String HOST_NAME = "Patty Placeholder's party";
@@ -99,7 +96,7 @@ public class FanActivity extends Activity {
     protected void onHelloButtonClicked() {
         //initial test message
         Toaster.iToast(this, "Sending hello message");
-        String message = "Hello, Fans.  From: " + BluetoothAdapter.getDefaultAdapter().getName();
+        String message = "You Rock! From: " + BluetoothAdapter.getDefaultAdapter().getName();
         StringMessage sm = new StringMessage();
         sm.setString(message);
         //send the message to the host
@@ -135,7 +132,7 @@ public class FanActivity extends Activity {
             @Override
             public boolean handleMessage(Message msg) {
                 if (msg.what == MessageThread.MESSAGE_READ) {
-                    onReadMessage(msg.obj.toString(), msg.arg1);
+                    onReadMessage(msg.arg1, (IMessage) msg.obj);
                     return true;
                 }
                 return false;
@@ -147,30 +144,12 @@ public class FanActivity extends Activity {
         this.messageThread.start();
     }
 
-    protected void onReadMessage(String string, int arg1) {
-        synchronized (msgMutex) {
-            if (message.length() > 0) {
-                message.append("\n");
-            } else {
-                startDelayedDisplayMessage();
-            }
-            message.append(string);
+    protected void onReadMessage(int messageNo, IMessage message) {
+        Log.w(TAG, "Message received: " + messageNo);
+        if (message instanceof StringMessage) {
+            StringMessage sm = (StringMessage)message;
+            Toaster.iToast(this, sm.getString());
         }
-    }
-
-    private void startDelayedDisplayMessage() {
-        int delayMillis = 2000; /* 2s */
-        new Handler().postDelayed(new Runnable() {
-
-            @Override
-            public void run() {
-                synchronized (msgMutex) {
-                    Toaster.iToast(FanActivity.this, message.toString());
-                    message = new StringBuilder();
-                }
-            }
-
-        }, delayMillis);
     }
 
     @Override

--- a/fanClub/src/com/lastcrusade/fanclub/HostActivity.java
+++ b/fanClub/src/com/lastcrusade/fanclub/HostActivity.java
@@ -39,15 +39,18 @@ public class HostActivity extends Activity {
         setContentView(R.layout.activity_host);
         Log.w(TAG, "Create Called");
 
+        // TODO consider moving this entire block into BluetoothUtils, because it's also used in FanActivity
         final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-
         try {
-            BluetoothUtils.checkAndEnableBluetooth(this, adapter);
-        } catch (BluetoothNotEnabledException e1) {
-            // TODO Auto-generated catch block
-            e1.printStackTrace();
+            BluetoothUtils.checkAndEnableBluetooth(adapter);
+        } catch (BluetoothNotEnabledException e) {
+            Toaster.iToast(this, "Unable to enable bluetooth adapter");
+            e.printStackTrace();
+            return;
+        } catch (BluetoothNotSupportedException e) {
+            Toaster.eToast(this, "Device may not support bluetooth");
+            e.printStackTrace();
         }
-
         registerReceivers(adapter);
 
         Button button = (Button) this.findViewById(R.id.button0);
@@ -144,6 +147,8 @@ public class HostActivity extends Activity {
             }
         }
         try {
+            //one thread per device found...if there are multiple devices,
+            // there are multiple threads
             this.connectThread = new ConnectThread(this, device) {
 
                 @Override

--- a/fanClub/src/com/lastcrusade/fanclub/UnableToCreateSocketException.java
+++ b/fanClub/src/com/lastcrusade/fanclub/UnableToCreateSocketException.java
@@ -1,0 +1,10 @@
+package com.lastcrusade.fanclub;
+
+import java.io.IOException;
+
+public class UnableToCreateSocketException extends IOException {
+
+    public UnableToCreateSocketException(Throwable tr) {
+        super(tr);
+    }
+}

--- a/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
+++ b/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
@@ -6,17 +6,36 @@ import android.content.Intent;
 
 import com.lastcrusade.fanclub.BluetoothNotEnabledException;
 import com.lastcrusade.fanclub.BluetoothNotSupportedException;
+import com.lastcrusade.fanclub.R;
 
 public class BluetoothUtils {
     /* All methods should be static */
     private final String TAG = "BluetoothUtils";
 
-    public static void checkAndEnableBluetooth(BluetoothAdapter adapter) throws BluetoothNotEnabledException, BluetoothNotSupportedException {
+    public static void checkAndEnableBluetooth(Context context, BluetoothAdapter adapter) throws BluetoothNotEnabledException, BluetoothNotSupportedException {
         if (adapter != null) {
             if (!adapter.isEnabled()) {
-                adapter.enable();
+                Toaster.iToast(context, R.string.enable_bluetooth);
+                boolean enableStarted = adapter.enable();
+                boolean enabled = false;
+                if (enableStarted) {
+                    //once the enable process is started, it takes some time to be enabled
+                    int retrySeconds = 5;
+                    int retryPauseMS = 500;
+                    int retries = (retrySeconds * 1000) / retryPauseMS;
+                    int retry = 0;
+                    do {
+                        try {
+                            Thread.sleep(retryPauseMS);
+                        } catch (InterruptedException e) {
+                            //nothing to do
+                        }
+                        enabled = adapter.isEnabled();
+                            
+                    } while (!enabled && retry++ < retries);                    
+                }
                 //TODO: do we need to wait until it's started here?  adapter.enable just says it's "starting up"
-                if (!adapter.isEnabled()) {
+                if (!enabled) {
                     throw new BluetoothNotEnabledException();
                 }
             }

--- a/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
+++ b/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
@@ -10,23 +10,32 @@ import com.lastcrusade.fanclub.R;
 
 public class BluetoothUtils {
     /* All methods should be static */
-    private final String TAG = "BluetoothUtils";
+    private static final String TAG = "BluetoothUtils";
+    
+    /* The maximum number of seconds in which to wait for bluetooth to enable */
+    private static final int ENABLE_CHECK_RETRY_SECONDS = 5;
+    
+    /* The number of milliseconds to wait in between calls to isEnabled */
+    private static final int ENABLE_CHECK_RETRY_PAUSE_MILLISECONDS = 500;
 
     public static void checkAndEnableBluetooth(Context context, BluetoothAdapter adapter) throws BluetoothNotEnabledException, BluetoothNotSupportedException {
         if (adapter != null) {
             if (!adapter.isEnabled()) {
                 Toaster.iToast(context, R.string.enable_bluetooth);
+                //start the adapter
                 boolean enableStarted = adapter.enable();
                 boolean enabled = false;
+                //we need to wait a bit for the enable to take effect...in this case, we poll the adapter's isEnabled method
+                // after some delay and check to see if the adapter has been enabled by a set amount of time
+                //NOTE: these constant times were picked somewhat randomly...the process should never take more than 5 seconds, and
+                // a 500ms delay between polls should be ok in this case.
                 if (enableStarted) {
                     //once the enable process is started, it takes some time to be enabled
-                    int retrySeconds = 5;
-                    int retryPauseMS = 500;
-                    int retries = (retrySeconds * 1000) / retryPauseMS;
+                    int retries = (ENABLE_CHECK_RETRY_SECONDS * 1000) / ENABLE_CHECK_RETRY_PAUSE_MILLISECONDS;
                     int retry = 0;
                     do {
                         try {
-                            Thread.sleep(retryPauseMS);
+                            Thread.sleep(ENABLE_CHECK_RETRY_PAUSE_MILLISECONDS);
                         } catch (InterruptedException e) {
                             //nothing to do
                         }
@@ -34,7 +43,6 @@ public class BluetoothUtils {
                             
                     } while (!enabled && retry++ < retries);                    
                 }
-                //TODO: do we need to wait until it's started here?  adapter.enable just says it's "starting up"
                 if (!enabled) {
                     throw new BluetoothNotEnabledException();
                 }

--- a/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
+++ b/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
@@ -5,24 +5,29 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.lastcrusade.fanclub.BluetoothNotEnabledException;
+import com.lastcrusade.fanclub.BluetoothNotSupportedException;
 
 public class BluetoothUtils {
     /* All methods should be static */
     private final String TAG = "BluetoothUtils";
 
-    public static void checkAndEnableBluetooth(Context context,
-            BluetoothAdapter adapter) throws BluetoothNotEnabledException {
+    public static void checkAndEnableBluetooth(BluetoothAdapter adapter) throws BluetoothNotEnabledException, BluetoothNotSupportedException {
         if (adapter != null) {
             if (!adapter.isEnabled()) {
                 adapter.enable();
+                //TODO: do we need to wait until it's started here?  adapter.enable just says it's "starting up"
                 if (!adapter.isEnabled()) {
                     throw new BluetoothNotEnabledException();
                 }
             }
         } else {
             //adapter == null means we may not support bluetooth
-            Toaster.eToast(context, "Device may not support bluetooth");
+            throw new BluetoothNotSupportedException();
         }
+    }
+
+    public static void disableDiscovery(Context context) {
+        //TODO: this
     }
 
     public static void enableDiscovery(Context context) {


### PR DESCRIPTION
These commits get us back to bluetooth-test functionality, with some additional functionality (e.g. Let Me In/FindNewFans button).  This implements the new discovery style (though not the whole new discovery process), and supports discovering multiple fans at once.  Tested using my Nexus4 and Reid's test Galaxy Nexus...there is some bad connection latency when there are a lot of other non-fanClub bluetooth devices nearby, and we need some way of detecting when a socket is dropped, but otherwise it tested fine.
