### PR TITLE
Major refactor of connection code

### DIFF
--- a/fanClub/AndroidManifest.xml
+++ b/fanClub/AndroidManifest.xml
@@ -48,6 +48,16 @@
             />
             
         <service
+            android:name=".service.ConnectionService"
+            android:exported="false"
+            />
+            
+        <service
+            android:name=".service.MessagingService"
+            android:exported="false"
+            />
+            
+        <service
             android:name=".service.MusicLibraryService"
             android:exported="false"
             android:label="@string/music_library"

--- a/fanClub/src/com/lastcrusade/fanclub/FanActivity.java
+++ b/fanClub/src/com/lastcrusade/fanclub/FanActivity.java
@@ -19,6 +19,7 @@ import com.lastcrusade.fanclub.service.IMessagingService;
 import com.lastcrusade.fanclub.service.MessagingService;
 import com.lastcrusade.fanclub.service.MessagingService.MessagingServiceBinder;
 import com.lastcrusade.fanclub.service.ServiceLocator;
+import com.lastcrusade.fanclub.service.ServiceLocator.IOnBindListener;
 import com.lastcrusade.fanclub.service.ServiceNotBoundException;
 import com.lastcrusade.fanclub.util.BroadcastRegistrar;
 import com.lastcrusade.fanclub.util.IBroadcastActionHandler;
@@ -26,7 +27,6 @@ import com.lastcrusade.fanclub.util.Toaster;
 
 public class FanActivity extends Activity {
 
-    private String HOST_NAME = "Patty Placeholder's party";
     private final String TAG = FanActivity.class.getName();
 
     private BroadcastRegistrar broadcastRegistrar;
@@ -46,10 +46,10 @@ public class FanActivity extends Activity {
                 this, MessagingService.class, MessagingServiceBinder.class);
 
 
-        connectionServiceLocator.setOnBindListener(new Runnable() {
+        connectionServiceLocator.setOnBindListener(new IOnBindListener() {
 
             @Override
-            public void run() {
+            public void onServiceBound() {
                 getConnectionService().broadcastFan(FanActivity.this);
             }
         });

--- a/fanClub/src/com/lastcrusade/fanclub/FanActivity.java
+++ b/fanClub/src/com/lastcrusade/fanclub/FanActivity.java
@@ -1,14 +1,9 @@
 package com.lastcrusade.fanclub;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
 import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
-import android.bluetooth.BluetoothDevice;
-import android.bluetooth.BluetoothServerSocket;
-import android.bluetooth.BluetoothSocket;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -16,70 +11,49 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 
-import com.lastcrusade.fanclub.components.IOnDialogItemClickListener;
-import com.lastcrusade.fanclub.components.MultiSelectListDialog;
-import com.lastcrusade.fanclub.net.AcceptThread;
-import com.lastcrusade.fanclub.net.BluetoothDeviceDialogFormatter;
-import com.lastcrusade.fanclub.net.BluetoothNotEnabledException;
-import com.lastcrusade.fanclub.net.BluetoothNotSupportedException;
-import com.lastcrusade.fanclub.net.MessageThread;
-import com.lastcrusade.fanclub.net.MessageThreadMessageDispatch;
-import com.lastcrusade.fanclub.net.MessageThreadMessageDispatch.IMessageHandler;
-import com.lastcrusade.fanclub.net.message.ConnectFansMessage;
-import com.lastcrusade.fanclub.net.message.FindNewFansMessage;
-import com.lastcrusade.fanclub.net.message.FoundFan;
-import com.lastcrusade.fanclub.net.message.FoundFansMessage;
 import com.lastcrusade.fanclub.net.message.IMessage;
 import com.lastcrusade.fanclub.net.message.StringMessage;
-import com.lastcrusade.fanclub.util.BluetoothUtils;
+import com.lastcrusade.fanclub.service.ConnectionService;
+import com.lastcrusade.fanclub.service.ConnectionService.ConnectionServiceBinder;
+import com.lastcrusade.fanclub.service.IMessagingService;
+import com.lastcrusade.fanclub.service.MessagingService;
+import com.lastcrusade.fanclub.service.MessagingService.MessagingServiceBinder;
+import com.lastcrusade.fanclub.service.ServiceLocator;
+import com.lastcrusade.fanclub.service.ServiceNotBoundException;
+import com.lastcrusade.fanclub.util.BroadcastRegistrar;
+import com.lastcrusade.fanclub.util.IBroadcastActionHandler;
 import com.lastcrusade.fanclub.util.Toaster;
 
 public class FanActivity extends Activity {
 
-    private final String TAG = "FanActivity";
-    private BluetoothServerSocket mmServerSocket;
     private String HOST_NAME = "Patty Placeholder's party";
-    protected MessageThread messageThread;
-    private MessageThreadMessageDispatch messageDispatch;
+    private final String TAG = FanActivity.class.getName();
 
+    private BroadcastRegistrar broadcastRegistrar;
+
+    private ServiceLocator<ConnectionService> connectionServiceLocator;
+    private ServiceLocator<MessagingService>  messagingServiceLocator;
+    
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_fan);
 
-        final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-        try {
-            BluetoothUtils.checkAndEnableBluetooth(this, adapter);
-        } catch (BluetoothNotEnabledException e) { // TODO This should be in
-                                                   // BluetoothUtils?
-            Toaster.iToast(this, "Unable to enable bluetooth adapter");
-            e.printStackTrace();
-            return;
-        } catch (BluetoothNotSupportedException e) {
-            Toaster.eToast(this, "Device may not support bluetooth");
-            e.printStackTrace();
-        }
-
-        BluetoothUtils.enableDiscovery(this);
-
-        try {
-            if (adapter == null) {
-                Toaster.eToast(this, "Unable to enable bluetooth adapter");
-            } else {
-                AcceptThread thread = new AcceptThread(this, adapter) {
-
-                    @Override
-                    protected void onAccepted(BluetoothSocket socket) {
-                        onAcceptedHost(socket);
-                    }
-                    
-                };
-                thread.execute();
-            }
-        } catch (IOException e) {
-            Log.w(TAG, e.getStackTrace().toString());
-        }
+        connectionServiceLocator = new ServiceLocator<ConnectionService>(
+                this, ConnectionService.class, ConnectionServiceBinder.class);
         
+        messagingServiceLocator = new ServiceLocator<MessagingService>(
+                this, MessagingService.class, MessagingServiceBinder.class);
+
+
+        connectionServiceLocator.setOnBindListener(new Runnable() {
+
+            @Override
+            public void run() {
+                getConnectionService().broadcastFan(FanActivity.this);
+            }
+        });
+
         Button button = (Button) this.findViewById(R.id.btn_let_me_in);
         button.setOnClickListener(new OnClickListener() {
 
@@ -98,96 +72,87 @@ public class FanActivity extends Activity {
             }
         });
         
-        registerMessageHandlers();
+        registerReceivers();
     }
 
-    private void registerMessageHandlers() {
-        this.messageDispatch = new MessageThreadMessageDispatch();
-        this.messageDispatch.registerHandler(StringMessage.class, new IMessageHandler<StringMessage>() {
+    private void registerReceivers() {
+        this.broadcastRegistrar = new BroadcastRegistrar();
+        this.broadcastRegistrar
+            .addAction(MessagingService.ACTION_STRING_MESSAGE, new IBroadcastActionHandler() {
 
-            @Override
-            public void handleMessage(int messageNo,
-                    StringMessage message, String fromAddr) {
-                StringMessage sm = (StringMessage)message;
-                Toaster.iToast(FanActivity.this, sm.getString());
-            }
-            
-        });
-        this.messageDispatch.registerHandler(FoundFansMessage.class, new IMessageHandler<FoundFansMessage>() {
+                @Override
+                public void onReceiveAction(Context context, Intent intent) {
+                    String string = intent.getStringExtra(MessagingService.EXTRA_STRING);
+                    Toaster.iToast(FanActivity.this, string);
+                }
+            })
+//            .addAction(ConnectionService.ACTION_FIND_FINISHED, new IBroadcastActionHandler() {
+//
+//                    @Override
+//                    public void onReceiveAction(Context context, Intent intent) {
+//                        onDiscoveredDevices(intent);
+//                        ((Button) findViewById(R.id.button0)).setEnabled(true);
+//                    }
+//                })
+            .register(this);
+    }
 
-            @Override
-            public void handleMessage(int messageNo,
-                    FoundFansMessage message, String fromAddr) {
-                handleFoundFans(message.getFoundFans());
-            }
-        });
+    private void unregisterReceivers() {
+        this.broadcastRegistrar.unregister();
+    }
+
+    protected ConnectionService getConnectionService() {
+        ConnectionService connectionService = null;
+        try {
+            connectionService = this.connectionServiceLocator.getService();
+        } catch (ServiceNotBoundException e) {
+            Log.wtf(TAG, e);
+        }
+        return connectionService;
+    }
+
+    protected IMessagingService getMessagingService() {
+        MessagingService messagingService = null;
+        try {
+            messagingService = this.messagingServiceLocator.getService();
+        } catch (ServiceNotBoundException e) {
+            Log.wtf(TAG, e);
+        }
+        return messagingService;
     }
 
     protected void onLetMeInButtonClicked() {
         //initial test message
         Toaster.iToast(this, "Sending Find New Fans message");
-        FindNewFansMessage msg = new FindNewFansMessage();
-        //send the message to the host
-        sendMessage(msg);
+        getMessagingService().sendFindNewFansMessage();
     }
 
     protected void onHelloButtonClicked() {
         //initial test message
         Toaster.iToast(this, "Sending hello message");
         String message = "You Rock! From: " + BluetoothAdapter.getDefaultAdapter().getName();
-        StringMessage sm = new StringMessage();
-        sm.setString(message);
-        //send the message to the host
-        sendMessage(sm);
+        getMessagingService().sendStringMessage(message);
     }
 
-    /**
-     * Helper method to send a message to the host or raise an error
-     * to the user.
-     * 
-     * @param msg
-     */
-    private void sendMessage(IMessage msg) {
-        if(this.messageThread == null){
-            Toaster.eToast(this, "Not connected to host");
-        } else {
-            this.messageThread.write(msg);
-        }        
-    }
-
-    private void handleFoundFans(List<FoundFan> list) {
-        if (list.isEmpty()) {
-            Toaster.iToast(this, R.string.no_fans_found);
-        } else {
-            Toaster.iToast(this, R.string.found_fans);
-            new MultiSelectListDialog<FoundFan>(this, R.string.select_fans, R.string.connect)
-                .setItems(list)
-                .setOnClickListener(new IOnDialogItemClickListener<FoundFan>() {
-
-                    @Override
-                    public void onItemClick(FoundFan device) {
-                        ConnectFansMessage msg = new ConnectFansMessage(Arrays.asList(device.getAddress()));
-                        messageThread.write(msg);
-                    }
-                })
-                .show();
-        }
-    }
-
-    /**
-     * 
-     * NOTE: must be run on the UI thread.
-     * 
-     * @param socket
-     */
-    protected void onAcceptedHost(BluetoothSocket socket) {
-        //disable discovery...we found our host.
-        BluetoothUtils.disableDiscovery(this);
-
-        //create the message thread for handling this connection
-        this.messageThread = new MessageThread(socket, this.messageDispatch);
-        this.messageThread.start();
-    }
+//    private void handleFoundFans(List<FoundFan> list) {
+//        if (list.isEmpty()) {
+//            Toaster.iToast(this, R.string.no_fans_found);
+//        } else {
+//            Toaster.iToast(this, R.string.found_fans);
+//            new MultiSelectListDialog<FoundFan>(this, R.string.select_fans, R.string.connect)
+//                .setItems(list)
+//                .setOnClickListener(new IOnDialogItemClickListener<FoundFan>() {
+//
+//                    @Override
+//                    public void onItemClick(FoundFan device) {
+//                        
+//                        ConnectFansMessage msg = new ConnectFansMessage(Arrays.asList(device.getAddress()));
+//                        messageThread.write(msg);
+//                    }
+//                })
+//                .show();
+//        }
+//    }
 
     protected void onReadMessage(int messageNo, IMessage message) {
         Log.w(TAG, "Message received: " + messageNo);

--- a/fanClub/src/com/lastcrusade/fanclub/net/message/ConnectFansMessage.java
+++ b/fanClub/src/com/lastcrusade/fanclub/net/message/ConnectFansMessage.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class ConnectFansMessage extends ADataMessage {
 
-    List<String> addresses = new ArrayList<String>();
+    private ArrayList<String> addresses = new ArrayList<String>();
     
     /**
      * Default constructor, required for Messenger.  All other users should use
@@ -38,7 +38,7 @@ public class ConnectFansMessage extends ADataMessage {
         }
     }
     
-    public List<String> getAddresses() {
+    public ArrayList<String> getAddresses() {
         return addresses;
     }
 }

--- a/fanClub/src/com/lastcrusade/fanclub/net/message/FoundFan.java
+++ b/fanClub/src/com/lastcrusade/fanclub/net/message/FoundFan.java
@@ -1,12 +1,20 @@
 package com.lastcrusade.fanclub.net.message;
 
-public class FoundFan {
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class FoundFan implements Parcelable {
     private String name;
     private String address;
 
     public FoundFan(String name, String address) {
         this.name = name;
         this.address = address;
+    }
+    
+    public FoundFan(Parcel in) {
+        this.name    = in.readString();
+        this.address = in.readString();
     }
 
     public String getAddress() {
@@ -62,5 +70,15 @@ public class FoundFan {
             return false;
         return true;
     }
-    
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(getName());
+        dest.writeString(getAddress());
+    }
 }

--- a/fanClub/src/com/lastcrusade/fanclub/net/message/FoundFansMessage.java
+++ b/fanClub/src/com/lastcrusade/fanclub/net/message/FoundFansMessage.java
@@ -10,7 +10,7 @@ import android.bluetooth.BluetoothDevice;
 
 public class FoundFansMessage extends ADataMessage {
 
-    private List<FoundFan> foundFans = new ArrayList<FoundFan>();
+    private ArrayList<FoundFan> foundFans = new ArrayList<FoundFan>();
     
     /**
      * Default constructor, required for Messenger.  All other users should use
@@ -43,7 +43,7 @@ public class FoundFansMessage extends ADataMessage {
         }
     }
     
-    public List<FoundFan> getFoundFans() {
+    public ArrayList<FoundFan> getFoundFans() {
         return foundFans;
     }
 }

--- a/fanClub/src/com/lastcrusade/fanclub/service/ConnectionService.java
+++ b/fanClub/src/com/lastcrusade/fanclub/service/ConnectionService.java
@@ -261,7 +261,7 @@ public class ConnectionService extends Service {
         }
     }
 
-    private boolean isHostConnected() {
+    public boolean isHostConnected() {
         return this.host != null;
     }
 

--- a/fanClub/src/com/lastcrusade/fanclub/service/ConnectionService.java
+++ b/fanClub/src/com/lastcrusade/fanclub/service/ConnectionService.java
@@ -1,11 +1,59 @@
 package com.lastcrusade.fanclub.service;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import android.app.Activity;
 import android.app.Service;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothSocket;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.IBinder;
+import android.util.Log;
+
+import com.lastcrusade.fanclub.R;
+import com.lastcrusade.fanclub.net.AcceptThread;
+import com.lastcrusade.fanclub.net.BluetoothDiscoveryHandler;
+import com.lastcrusade.fanclub.net.BluetoothNotEnabledException;
+import com.lastcrusade.fanclub.net.BluetoothNotSupportedException;
+import com.lastcrusade.fanclub.net.ConnectThread;
+import com.lastcrusade.fanclub.net.MessageThread;
+import com.lastcrusade.fanclub.net.MessageThreadMessageDispatch;
+import com.lastcrusade.fanclub.net.message.FindNewFansMessage;
+import com.lastcrusade.fanclub.net.message.FoundFan;
+import com.lastcrusade.fanclub.net.message.FoundFansMessage;
+import com.lastcrusade.fanclub.net.message.IMessage;
+import com.lastcrusade.fanclub.service.MessagingService.MessagingServiceBinder;
+import com.lastcrusade.fanclub.util.BluetoothUtils;
+import com.lastcrusade.fanclub.util.BroadcastRegistrar;
+import com.lastcrusade.fanclub.util.IBroadcastActionHandler;
+import com.lastcrusade.fanclub.util.Toaster;
 
 public class ConnectionService extends Service {
+
+    private static final String TAG = ConnectionService.class.getName();
+
+    /**
+     * Action to indicate find fans action has finished.  This action is sent in response to local UI initiated
+     * find.
+     * 
+     * This uses EXTRA_DEVICES to report the devices found.
+     * 
+     */
+    public static final String ACTION_FIND_FINISHED        = ConnectionService.class.getName() + ".action.FindFinished";
+    /**
+     * Action to indicate find fans action has finished.  This action is sent in response to a remote FindNewFans message.
+     * 
+     * This uses EXTRA_DEVICES to report the devices found.
+     * 
+     */
+    public static final String ACTION_REMOTE_FIND_FINISHED = ConnectionService.class.getName() + ".action.RemoteFindFinished";
+    public static final String EXTRA_DEVICES               = ConnectionService.class.getName() + ".extra.Devices";
+
 
     /**
      * Class for clients to access.  Because we know this service always
@@ -18,9 +66,286 @@ public class ConnectionService extends Service {
         }
     }
 
+    private BluetoothAdapter adapter;
+    private List<ConnectThread> pendingConnections = new ArrayList<ConnectThread>();
+    private List<MessageThread> fans     = new ArrayList<MessageThread>();
+    private MessageThreadMessageDispatch messageDispatch;
+    private ServiceLocator<MessagingService> messagingServiceLocator;
+    private BluetoothDiscoveryHandler bluetoothDiscoveryHandler;
+
+    private MessageThread discoveryInitiator;
+
+    private BroadcastRegistrar broadcastRegistrar;
+
+    private MessageThread host;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        
+        this.adapter = BluetoothAdapter.getDefaultAdapter();
+        try {
+            BluetoothUtils.checkAndEnableBluetooth(this, adapter);
+        } catch (BluetoothNotEnabledException e) {
+            Toaster.iToast(this, "Unable to enable bluetooth adapter");
+            e.printStackTrace();
+            return;
+        } catch (BluetoothNotSupportedException e) {
+            Toaster.eToast(this, "Device may not support bluetooth");
+            e.printStackTrace();
+        }
+        
+        registerReceivers();
+        
+        this.bluetoothDiscoveryHandler = new BluetoothDiscoveryHandler(this, adapter);
+        this.messagingServiceLocator = new ServiceLocator<MessagingService>(
+                this, MessagingService.class, MessagingServiceBinder.class);
+        
+        this.messageDispatch = new MessageThreadMessageDispatch() {
+            
+            @Override
+            public void handleMessage(int messageNo, IMessage message,
+                    String fromAddr) {
+                if (message instanceof FindNewFansMessage) {
+                    
+                } else {
+                    try {
+                        messagingServiceLocator.getService().receiveMessage(messageNo, message, fromAddr);
+                    } catch (ServiceNotBoundException e) {
+                        Log.wtf(TAG, e);
+                    }
+                }
+            }
+        };
+    }
+
     @Override
     public IBinder onBind(Intent intent) {
         return new ConnectionServiceBinder();
     }
 
+    @Override
+    public boolean onUnbind(Intent intent) {
+        return super.onUnbind(intent);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        unregisterReceivers();
+        this.messagingServiceLocator.unbind();
+    }
+
+    private void registerReceivers() {
+        this.broadcastRegistrar = new BroadcastRegistrar();
+        this.broadcastRegistrar
+            .addAction(BluetoothAdapter.ACTION_DISCOVERY_STARTED, new IBroadcastActionHandler() {
+
+                @Override
+                public void onReceiveAction(Context context, Intent intent) {
+                    bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiator != null);
+                }
+            })
+           .addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED, new IBroadcastActionHandler() {
+
+                @Override
+                public void onReceiveAction(Context context, Intent intent) {
+                    bluetoothDiscoveryHandler.onDiscoveryFinished();
+                }
+            })
+           .addAction(BluetoothDevice.ACTION_FOUND, new IBroadcastActionHandler() {
+
+                @Override
+                public void onReceiveAction(Context context, Intent intent) {
+                    bluetoothDiscoveryHandler.onDiscoveryFound(
+                            (BluetoothDevice) intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE));
+                }
+            })
+           .addAction(ConnectionService.ACTION_REMOTE_FIND_FINISHED, new IBroadcastActionHandler() {
+            
+                @Override
+                public void onReceiveAction(Context context, Intent intent) {
+                    //remote initiated device discovery...we want to send the list of devices back to the client
+                    List<BluetoothDevice> devices = intent.getParcelableArrayListExtra(ConnectionService.EXTRA_DEVICES);
+                    List<FoundFan> foundFans = new ArrayList<FoundFan>();
+                    for (BluetoothDevice device : devices) {
+                        // send the found fans back to the client.
+                        foundFans.add(new FoundFan(device.getName(), device.getAddress()));
+                    }
+                    FoundFansMessage msg = new FoundFansMessage(
+                            foundFans);
+                    discoveryInitiator.write(msg);
+                }
+            })
+           .register(this);
+    }
+
+    private void unregisterReceivers() {
+        this.broadcastRegistrar.unregister();
+    }
+    
+    /**
+     * Handle the FindNewFansMessage, which enables discovery on this device and
+     * reports the results back to the requestor.
+     * 
+     * @param remoteAddr
+     */
+    private void handleFindNewFansMessage(final String remoteAddr) {
+        Toaster.iToast(this, R.string.finding_new_fans);
+
+        //NOTE: we assume that the adapter is nonnull, because the activity will not
+        // get past onCreate on a device w/o Bluetooth...and also, because this method is
+        // called in response to a network message over Bluetooth
+        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+
+        // look up the message thread that manages the connection to the remote
+        // device
+        BluetoothDevice remoteDevice = adapter.getRemoteDevice(remoteAddr);
+        MessageThread found = null;
+        for (MessageThread thread : this.fans) {
+            if (thread.isRemoteDevice(remoteDevice)) {
+                found = thread;
+                break;
+            }
+        }
+
+        if (found == null) {
+            Log.wtf(TAG, "Unknown remote device: " + remoteAddr);
+            return;
+        }
+
+        this.discoveryInitiator = found;
+        findNewFans();
+    }
+
+    /**
+     * 
+     * NOTE: must be run on the UI thread.
+     * 
+     * @param socket
+     */
+    protected void onConnectedFan(BluetoothSocket socket) {
+        Log.w(TAG, "Connected to server");
+
+        //create the message thread, which will be responsible for reading and writing messages
+        MessageThread newMessageThread = new MessageThread(socket, this.messageDispatch);
+        newMessageThread.start();
+        this.fans.add(newMessageThread);
+    }
+
+    public void findNewFans() {
+        Log.w(TAG, "Starting Discovery");
+        if (adapter == null) {
+            Toaster.iToast(this,
+                    "Device may not support bluetooth");
+        } else {
+            adapter.startDiscovery();
+        }
+    }
+
+    public void broadcastMessageToFans(IMessage msg) {
+        if (isFanConnected()) {
+            for (MessageThread fan : this.fans) {
+                fan.write(msg);
+            }
+        } else {
+            Toaster.eToast(this, "No Fans connected");
+        }
+    }
+
+    public void sendMessageToHost(IMessage msg) {
+        if (isHostConnected()) {
+            this.host.write(msg);
+        } else {
+            Toaster.eToast(this, "Not connected to host");
+        }
+    }
+
+    private boolean isHostConnected() {
+        return this.host != null;
+    }
+
+    public void disconnectAllFans() {
+        for (MessageThread thread : this.fans) {
+            thread.cancel();
+        }
+    }
+
+    public boolean isFanConnected() {
+        return !this.fans.isEmpty();
+    }
+
+    /**
+     * NOTE: must be run on the UI thread.
+     * 
+     * @param device
+     */
+    public void connectToFan(BluetoothDevice device) {
+        try {
+            //one thread per device found...if there are multiple devices,
+            // there are multiple threads
+            //TODO: asyncTask may not work....if the host discovers 4 devices, it appears to still only use 1 async task thread
+            // and if the first 3 of those devices are not fanclub, itll pause for a while attempting to conenct, which will delay
+            // connection of the actual fan
+            ConnectThread connectThread = new ConnectThread(this, device) {
+
+                @Override
+                protected void onConnected(BluetoothSocket socket) {
+                    pendingConnections.remove(this);
+                    onConnectedFan(socket);
+                }
+                
+            };
+            this.pendingConnections.add(connectThread);
+            connectThread.execute();
+        } catch (IOException e) {
+            e.printStackTrace();
+            Toaster.iToast(this,
+                    "Unable to create ConnectThread to connect to server");
+        }
+    }
+
+    /**
+     * NOTE: Must be called from an activity
+     * 
+     * TODO: this exposes an implementation detail, namely that bluetooth discoverability
+     * @param activity
+     */
+    public void broadcastFan(Activity activity) {
+        BluetoothUtils.enableDiscovery(activity);
+
+        try {
+            if (adapter == null) {
+                Toaster.eToast(this, "Unable to enable bluetooth adapter");
+            } else {
+                AcceptThread thread = new AcceptThread(this, adapter) {
+
+                    @Override
+                    protected void onAccepted(BluetoothSocket socket) {
+                        onAcceptedHost(socket);
+                    }
+                    
+                };
+                thread.execute();
+            }
+        } catch (IOException e) {
+            Log.w(TAG, e.getStackTrace().toString());
+        }
+    }
+    
+
+    /**
+     * 
+     * NOTE: must be run on the UI thread.
+     * 
+     * @param socket
+     */
+    protected void onAcceptedHost(BluetoothSocket socket) {
+        //disable discovery...we found our host.
+        BluetoothUtils.disableDiscovery(this);
+
+        //create the message thread for handling this connection
+        this.host = new MessageThread(socket, this.messageDispatch);
+        this.host.start();
+    }
 }

--- a/fanClub/src/com/lastcrusade/fanclub/service/IMessagingService.java
+++ b/fanClub/src/com/lastcrusade/fanclub/service/IMessagingService.java
@@ -1,0 +1,7 @@
+package com.lastcrusade.fanclub.service;
+
+public interface IMessagingService {
+
+    public void sendFindNewFansMessage();
+    public void sendStringMessage(String message);
+}

--- a/fanClub/src/com/lastcrusade/fanclub/service/MessagingService.java
+++ b/fanClub/src/com/lastcrusade/fanclub/service/MessagingService.java
@@ -214,7 +214,20 @@ public class MessagingService extends Service implements IMessagingService {
     public void sendStringMessage(String message) {
         StringMessage sm = new StringMessage();
         sm.setString(message);
-        //send the message to the host
-        sendMessageToHost(sm);
+        //JR, 03/02/12, TODO: the connection service should be changed to only deal with "connections".  The mode of connection will
+        // be determined by which method is called initially (braodcastFan vs findNewFans), but after that point, it should just
+        // work with connections
+        try {
+            //send the message to the host
+            if (this.connectServiceLocator.getService().isHostConnected()) {
+                sendMessageToHost(sm);
+            }
+            
+            if (this.connectServiceLocator.getService().isFanConnected()) {
+                broadcastMessageToFans(sm);
+            }
+        } catch (ServiceNotBoundException e) {
+            Log.wtf(TAG, e);
+        }
     }
 }

--- a/fanClub/src/com/lastcrusade/fanclub/service/MessagingService.java
+++ b/fanClub/src/com/lastcrusade/fanclub/service/MessagingService.java
@@ -1,0 +1,170 @@
+package com.lastcrusade.fanclub.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+import android.util.Log;
+
+import com.lastcrusade.fanclub.net.MessageThread;
+import com.lastcrusade.fanclub.net.MessageThreadMessageDispatch;
+import com.lastcrusade.fanclub.net.MessageThreadMessageDispatch.IMessageHandler;
+import com.lastcrusade.fanclub.net.message.ConnectFansMessage;
+import com.lastcrusade.fanclub.net.message.FindNewFansMessage;
+import com.lastcrusade.fanclub.net.message.FoundFansMessage;
+import com.lastcrusade.fanclub.net.message.IMessage;
+import com.lastcrusade.fanclub.net.message.StringMessage;
+import com.lastcrusade.fanclub.service.ConnectionService.ConnectionServiceBinder;
+import com.lastcrusade.fanclub.util.BroadcastIntent;
+import com.lastcrusade.fanclub.util.BroadcastRegistrar;
+import com.lastcrusade.fanclub.util.Toaster;
+
+public class MessagingService extends Service implements IMessagingService {
+
+    private static final String TAG = MessagingService.class.getName();
+
+    public static final String ACTION_STRING_MESSAGE = MessagingService.class.getName() + ".action.StringMessage";
+    public static final String EXTRA_STRING          = MessagingService.class.getName() + ".extra.String";
+    
+    public static final String ACTION_FOUND_FANS_MESSAGE = MessagingService.class.getName() + ".action.FoundFansMessage";
+    public static final String EXTRA_FOUND_FANS          = MessagingService.class.getName() + ".extra.FoundFans";
+    
+    public static final String ACTION_CONNECT_FANS_MESSAGE = MessagingService.class.getName() + ".action.ConnectFansMessage";
+    public static final String EXTRA_FAN_ADDRESSES         = MessagingService.class.getName() + ".extra.FanAddresses";
+    
+    public static final String ACTION_FIND_FANS_MESSAGE = MessagingService.class.getName() + ".action.FindFansMessage";
+    public static final String EXTRA_REQUEST_ADDRESS    = MessagingService.class.getName() + ".extra.RequestAddress";
+    
+    /**
+     * Class for clients to access.  Because we know this service always
+     * runs in the same process as its clients, we don't need to deal with
+     * IPC.
+     */
+    public class MessagingServiceBinder extends Binder implements ILocalBinder<MessagingService> {
+        public MessagingService getService() {
+            return MessagingService.this;
+        }
+    }
+
+    private BroadcastRegistrar                broadcastRegistrar;
+    private MessageThreadMessageDispatch      messageDispatch;
+    private Map<IMessage, String>             actionDispatchMap;
+    private ServiceLocator<ConnectionService> connectServiceLocator;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        this.actionDispatchMap = new HashMap<IMessage, String>();
+        this.connectServiceLocator = new ServiceLocator<ConnectionService>(
+                this, ConnectionService.class, ConnectionServiceBinder.class);
+        
+        registerMessageHandlers();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return new MessagingServiceBinder();
+    }
+    
+    @Override
+    public boolean onUnbind(Intent intent) {
+        return super.onUnbind(intent);
+    }
+
+    public void receiveMessage(int messageNo, IMessage message, String fromAddr) {
+        this.messageDispatch.handleMessage(messageNo, message, fromAddr);
+    }
+
+    private void registerMessageHandlers() {
+        this.messageDispatch = new MessageThreadMessageDispatch();
+        registerStringMessageHandler();
+        registerFindNewFansMessageHandler();
+        registerConnectFansMessageHandler();
+        registerFoundFansHandler();
+    }
+
+    private void registerFoundFansHandler() {
+        this.messageDispatch.registerHandler(FoundFansMessage.class, new IMessageHandler<FoundFansMessage>() {
+
+            @Override
+            public void handleMessage(int messageNo,
+                    FoundFansMessage message, String fromAddr) {
+                new BroadcastIntent(ACTION_FOUND_FANS_MESSAGE)
+                    .putParcelableArrayListExtra(EXTRA_FOUND_FANS, message.getFoundFans())
+                    .send(MessagingService.this);
+            }
+        });
+    }
+
+    private void registerConnectFansMessageHandler() {
+        this.messageDispatch.registerHandler(ConnectFansMessage.class, new IMessageHandler<ConnectFansMessage>() {
+
+            @Override
+            public void handleMessage(int messageNo,
+                    ConnectFansMessage message, String fromAddr) {
+                new BroadcastIntent(ACTION_CONNECT_FANS_MESSAGE)
+                    .putStringArrayListExtra(EXTRA_FAN_ADDRESSES, message.getAddresses())
+                    .send(MessagingService.this);
+            }
+        });
+    }
+
+    private void registerFindNewFansMessageHandler() {
+        this.messageDispatch.registerHandler(FindNewFansMessage.class, new IMessageHandler<FindNewFansMessage>() {
+
+            @Override
+            public void handleMessage(int messageNo,
+                    FindNewFansMessage message, String fromAddr) {
+                new BroadcastIntent(ACTION_FIND_FANS_MESSAGE)
+                    .putExtra(EXTRA_REQUEST_ADDRESS, fromAddr)
+                    .send(MessagingService.this);
+            }
+        });
+    }
+
+    private void registerStringMessageHandler() {
+        this.messageDispatch.registerHandler(StringMessage.class, new IMessageHandler<StringMessage>() {
+
+            @Override
+            public void handleMessage(int messageNo,
+                    StringMessage message, String fromAddr) {
+                StringMessage sm = (StringMessage) message;
+                new BroadcastIntent(ACTION_STRING_MESSAGE)
+                    .putExtra(EXTRA_STRING, sm.getString())
+                    .send(MessagingService.this);
+            }            
+        });
+    }
+
+    private void broadcastMessageToFans(IMessage msg) {
+        try {
+            this.connectServiceLocator.getService().broadcastMessageToFans(msg);
+        } catch (ServiceNotBoundException e) {
+            Log.wtf(TAG, e);
+        }
+    }
+
+    public void sendFindNewFansMessage() {
+        FindNewFansMessage msg = new FindNewFansMessage();
+        //send the message to the host
+        sendMessageToHost(msg);
+    }
+
+    private void sendMessageToHost(IMessage msg) {
+        try {
+            this.connectServiceLocator.getService().sendMessageToHost(msg);
+        } catch (ServiceNotBoundException e) {
+            Log.wtf(TAG, e);
+        }
+    }
+    
+    public void sendStringMessage(String message) {
+        StringMessage sm = new StringMessage();
+        sm.setString(message);
+        //send the message to the host
+        sendMessageToHost(sm);
+    }
+}

--- a/fanClub/src/com/lastcrusade/fanclub/service/ServiceLocator.java
+++ b/fanClub/src/com/lastcrusade/fanclub/service/ServiceLocator.java
@@ -9,22 +9,40 @@ import android.os.IBinder;
 
 /**
  * A generic class for launching/locating services.  As a general pattern, create locators
- * in onCreate or onResume for any services you may need in that activity.  The binding/launching process
- * happens in the message loop, so you MUST return from the on* method for the service to actually launch.
+ * in onCreate or onResume for any services you may need in that activity.
+ * 
  * After the service is bound, use getService to get the service object.
+ * 
+ * NOTE: The binding/launching process happens in the message loop, so you MUST return from the
+ * on* method for the service to actually launch.  We've seen that services bound in onCreate
+ * will not be launched/bound by onResume, which means that any intent receivers or action/click
+ * handlers that may get fired before or after onResume will not have access to the service.  If
+ * you need to use the service to load data for the UI, or need to register receivers that use the
+ * service, use an OnBindListener
  * 
  * @author Jesse Rosalia
  *
- * @param <T>
+ * @param <T> The service to locate.
  */
 public class ServiceLocator<T extends Service> implements ServiceConnection {
+
+    /**
+     * Used to listen for when a service is bound.  This is similar to Android's
+     * ServiceConnection, but much simpler.
+     * 
+     * @author Jesse Rosalia
+     *
+     */
+    public interface IOnBindListener {
+        public void onServiceBound();
+    }
 
     private T service;
     private boolean bound;
     private Class<? extends ILocalBinder<T>> serviceBinderClass;
     private Class<T> serviceClass;
     private Context context;
-    private Runnable onBindListener;
+    private IOnBindListener onBindListener;
 
     public ServiceLocator(Context context, Class<T> serviceClass, Class<? extends ILocalBinder<T>> binderClass) {
         this.context      = context;
@@ -40,7 +58,7 @@ public class ServiceLocator<T extends Service> implements ServiceConnection {
         service = serviceBinderClass.cast(iservice).getService();
         bound = true;
         if (onBindListener != null) {
-            this.onBindListener.run();
+            this.onBindListener.onServiceBound();
         }
     }
 
@@ -49,7 +67,7 @@ public class ServiceLocator<T extends Service> implements ServiceConnection {
         bound = false;
     }
     
-    public void setOnBindListener(Runnable onBindListener) {
+    public void setOnBindListener(IOnBindListener onBindListener) {
         this.onBindListener = onBindListener;
     }
 

--- a/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
+++ b/fanClub/src/com/lastcrusade/fanclub/util/BluetoothUtils.java
@@ -71,6 +71,9 @@ public class BluetoothUtils {
         discoverableIntent.putExtra(
                 BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, 300);
         context.startActivity(discoverableIntent);
+//        new BroadcastIntent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE)
+//            .putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, 300)
+//            .send(context);
     }
     
     public static String getLocalBluetoothName() {

--- a/fanClub/src/com/lastcrusade/fanclub/util/BroadcastIntent.java
+++ b/fanClub/src/com/lastcrusade/fanclub/util/BroadcastIntent.java
@@ -21,6 +21,24 @@ public class BroadcastIntent extends Intent {
     public BroadcastIntent(String action) {
         super.setAction(action);
     }    
+    
+    //Overridden to return BroadcastIntent, so we can chain method calls
+    @Override
+    public BroadcastIntent putExtra(String name, boolean value) {
+        return (BroadcastIntent) super.putExtra(name, value);
+    }
+
+    //Overridden to return BroadcastIntent, so we can chain method calls
+    @Override
+    public BroadcastIntent putExtra(String name, int value) {
+        return (BroadcastIntent) super.putExtra(name, value);
+    }
+
+    //Overridden to return BroadcastIntent, so we can chain method calls
+    @Override
+    public BroadcastIntent putExtra(String name, String value) {
+        return (BroadcastIntent) super.putExtra(name, value);
+    }
 
     //Overridden to return BroadcastIntent, so we can chain method calls
     @Override
@@ -29,6 +47,12 @@ public class BroadcastIntent extends Intent {
         return (BroadcastIntent) super.putParcelableArrayListExtra(name, value);
     }
 
+    //Overridden to return BroadcastIntent, so we can chain method calls
+    @Override
+    public BroadcastIntent putStringArrayListExtra(String name, ArrayList<String> value) {
+        return (BroadcastIntent) super.putStringArrayListExtra(name, value);
+    }
+    
     public void send(Context context) {
         context.sendBroadcast(this);
     }


### PR DESCRIPTION
 Connection code from HostActivity and FanActivity pulled into ConnectionService and MessagingService.

All connection management code now lives in ConnectionService.  This includes
bluetooth discovery, host/fan connection management, and sending and receiving
messages.

All messaging management code now lives in MessagingServices.  It receives new
IMessage objects from the ConnectionService, decomposes the messages into their
parts, and sends a broadcast intent/action to the rest of the system to
represent each message.  This decouples the message and network layer from the
rest of the app.

HostActivity and FanActivity have been modified to use these services.

Currently broken: remote fan discovery.  Not too far from being complete...
