### PR TITLE
Transfer library to all fans once the library is updated.  This happens ...

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/CustomApp.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/CustomApp.java
@@ -60,7 +60,7 @@ public class CustomApp extends Application {
                     String bluetoothID = intent.getStringExtra(ConnectionService.EXTRA_FAN_NAME);
                     String macAddress  = intent.getStringExtra(ConnectionService.EXTRA_FAN_ADDRESS);
                     userList.addUser(bluetoothID, macAddress);
-                    userList.notifyUpdate(CustomApp.this);                    
+                    userList.notifyUpdate(CustomApp.this);
                 }
             })
             .addAction(ConnectionService.ACTION_FAN_DISCONNECTED, new IBroadcastActionHandler() {
@@ -102,5 +102,5 @@ public class CustomApp extends Application {
             Log.wtf(TAG, e);
         }
         return messagingService;
-    }    
+    }
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/CustomApp.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/CustomApp.java
@@ -7,12 +7,12 @@ import android.util.Log;
 
 import com.lastcrusade.soundstream.model.UserList;
 import com.lastcrusade.soundstream.service.ConnectionService;
+import com.lastcrusade.soundstream.service.ConnectionService.ConnectionServiceBinder;
 import com.lastcrusade.soundstream.service.IMessagingService;
 import com.lastcrusade.soundstream.service.MessagingService;
+import com.lastcrusade.soundstream.service.MessagingService.MessagingServiceBinder;
 import com.lastcrusade.soundstream.service.ServiceLocator;
 import com.lastcrusade.soundstream.service.ServiceNotBoundException;
-import com.lastcrusade.soundstream.service.ConnectionService.ConnectionServiceBinder;
-import com.lastcrusade.soundstream.service.MessagingService.MessagingServiceBinder;
 import com.lastcrusade.soundstream.util.BroadcastRegistrar;
 import com.lastcrusade.soundstream.util.IBroadcastActionHandler;
 
@@ -60,7 +60,7 @@ public class CustomApp extends Application {
                     String bluetoothID = intent.getStringExtra(ConnectionService.EXTRA_FAN_NAME);
                     String macAddress  = intent.getStringExtra(ConnectionService.EXTRA_FAN_ADDRESS);
                     userList.addUser(bluetoothID, macAddress);
-                    userList.notifyUpdate(CustomApp.this);
+                    userList.notifyUpdate(CustomApp.this);                    
                 }
             })
             .addAction(ConnectionService.ACTION_FAN_DISCONNECTED, new IBroadcastActionHandler() {
@@ -102,5 +102,5 @@ public class CustomApp extends Application {
             Log.wtf(TAG, e);
         }
         return messagingService;
-    }
+    }    
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/components/ConnectFragment.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/components/ConnectFragment.java
@@ -58,8 +58,6 @@ public class ConnectFragment extends SherlockFragment implements ITitleable{
             
             @Override
             public void onClick(View v) {
-                //TODO: these will go away once Elizabeth completes her transition singleton
-                ((CoreActivity)getActivity()).onConnected();
                 Transitions.transitionToNetwork((CoreActivity)getActivity());
             }
         });
@@ -108,11 +106,10 @@ public class ConnectFragment extends SherlockFragment implements ITitleable{
                         //send the library to the connected host
                         try {
                             List<SongMetadata> metadata = getMusicLibraryService().getMyLibrary();
-                            getMessagingService().sendLibraryMessage(metadata);
+                            getMessagingService().sendLibraryMessageToHost(metadata);
                         } catch (ServiceNotBoundException e) {
                             Log.wtf(TAG, e);
                         }
-                        ((CoreActivity)getActivity()).onConnected();
                         //switch 
                         Transitions.transitionToHome((CoreActivity)getActivity());
                     }

--- a/SoundStream/src/com/lastcrusade/soundstream/service/IMessagingService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/IMessagingService.java
@@ -6,10 +6,50 @@ import com.lastcrusade.soundstream.model.SongMetadata;
 
 public interface IMessagingService {
 
-    public void sendLibraryMessage(List<SongMetadata> library);
+    /**
+     * Send the library to the currently connected host.
+     * 
+     * @param library
+     */
+    public void sendLibraryMessageToHost(List<SongMetadata> library);
+    
+    /**
+     * Send the library to all currently connected fans.
+     * 
+     * @param library
+     */
+    public void sendLibraryMessageToFans(List<SongMetadata> library);
+    
+    /**
+     * Send a find new fans message to the host.
+     * 
+     */
     public void sendFindNewFansMessage();
+    
+    /**
+     * Send a pause message to the host.
+     * 
+     */
     public void sendPauseMessage();
+    
+    /**
+     * Send a play message to the host.
+     * 
+     */
     public void sendPlayMessage();
+    
+    /**
+     * Send a skip message to the host.
+     * 
+     */
     public void sendSkipMessage();
+    
+    /**
+     * FOR TESTING
+     * 
+     * Send a string message to all connected devices (host or fan).
+     * 
+     * @param message
+     */
     public void sendStringMessage(String message);
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/service/MessagingService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/MessagingService.java
@@ -257,7 +257,6 @@ public class MessagingService extends Service implements IMessagingService {
         LibraryMessage msg = new LibraryMessage(library);
         //send the message to the host
         sendMessageToHost(msg);
-
     }
     
     @Override

--- a/SoundStream/src/com/lastcrusade/soundstream/service/MessagingService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/MessagingService.java
@@ -228,7 +228,9 @@ public class MessagingService extends Service implements IMessagingService {
 
     private void broadcastMessageToFans(IMessage msg) {
         try {
-            this.connectServiceLocator.getService().broadcastMessageToFans(msg);
+            if (this.connectServiceLocator.getService().isFanConnected()) {
+                this.connectServiceLocator.getService().broadcastMessageToFans(msg);
+            }
         } catch (ServiceNotBoundException e) {
             Log.wtf(TAG, e);
         }
@@ -236,7 +238,9 @@ public class MessagingService extends Service implements IMessagingService {
 
     private void sendMessageToHost(IMessage msg) {
         try {
-            this.connectServiceLocator.getService().sendMessageToHost(msg);
+            if (this.connectServiceLocator.getService().isHostConnected()) {
+                this.connectServiceLocator.getService().sendMessageToHost(msg);
+            }
         } catch (ServiceNotBoundException e) {
             Log.wtf(TAG, e);
         }
@@ -249,10 +253,18 @@ public class MessagingService extends Service implements IMessagingService {
     }
 
     @Override
-    public void sendLibraryMessage(List<SongMetadata> library) {
+    public void sendLibraryMessageToHost(List<SongMetadata> library) {
         LibraryMessage msg = new LibraryMessage(library);
         //send the message to the host
         sendMessageToHost(msg);
+
+    }
+    
+    @Override
+    public void sendLibraryMessageToFans(List<SongMetadata> library) {
+        LibraryMessage msg = new LibraryMessage(library);
+        //send the message to the fans
+        broadcastMessageToFans(msg);
     }
 
     @Override


### PR DESCRIPTION
...when

updateLibrary is called with notify=true (currently done when a library message
is received).  In this case, we attempt to update any fans, or fail gracefully
if no fans are created.

Fixed bug where fan could not get back to connect page after host has
disconnected.
