### PR TITLE
Continuous play / title in playbar fragment

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/audio/IPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/IPlayer.java
@@ -9,12 +9,17 @@ package com.lastcrusade.soundstream.audio;
  */
 public interface IPlayer {
 
+    public boolean isPaused();
+
     public boolean isPlaying();
     
     public void play();
 
     public void pause();
     
+    public void resume();
+    
     public void skip();
+
 
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/RemoteAudioPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/RemoteAudioPlayer.java
@@ -13,6 +13,7 @@ import com.lastcrusade.soundstream.util.IBroadcastActionHandler;
 public class RemoteAudioPlayer implements IPlayer {
 
     private CustomApp application;
+    private boolean paused;
     private boolean playing;
     
     BroadcastRegistrar registrar;
@@ -20,12 +21,18 @@ public class RemoteAudioPlayer implements IPlayer {
     public RemoteAudioPlayer(CustomApp application) {
         this.application = application;
         this.playing = false;
+        this.paused  = false;
         registerReceivers();
     }
 
     @Override
+    public boolean isPaused() {
+        return this.paused;
+    }
+    
+    @Override
     public boolean isPlaying() {
-        return this.playing;
+        return this.playing && !this.paused;
     }
 
     @Override
@@ -44,6 +51,15 @@ public class RemoteAudioPlayer implements IPlayer {
     }
 
     @Override
+    public void resume() {
+        //TODO: see above
+        this.playing = true;
+        this.paused  = false;
+        //TODO: this should probably send a resume message
+        this.application.getMessagingService().sendPlayMessage();
+    }
+
+    @Override
     public void skip() {
         this.application.getMessagingService().sendSkipMessage();
     }
@@ -57,9 +73,11 @@ public class RemoteAudioPlayer implements IPlayer {
 			public void onReceiveAction(Context context, Intent intent) {
 				playing = intent.getBooleanExtra(MessagingService.EXTRA_IS_PLAYING, false);
 				if(playing) {
+				    paused = false;
 					new BroadcastIntent(PlaylistService.ACTION_PLAYING_AUDIO).send(application);
 				}
 				else {
+				    paused = true;
 					new BroadcastIntent(PlaylistService.ACTION_PAUSED_AUDIO).send(application);
 				}
 			}

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
@@ -27,6 +27,8 @@ public class SingleFileAudioPlayer implements IPlayer {
     private String filePath;
     private MediaPlayer player;
 
+    private boolean paused;
+
     public SingleFileAudioPlayer(final Context context) {
         this.player = new MediaPlayer();
         player.setOnCompletionListener(
@@ -43,7 +45,7 @@ public class SingleFileAudioPlayer implements IPlayer {
 
     @Override
     public boolean isPlaying() {
-        return player.isPlaying();
+        return player.isPlaying() && !paused;
     }
 
     public void play() {
@@ -54,6 +56,7 @@ public class SingleFileAudioPlayer implements IPlayer {
             if (player.isPlaying()) {
                 player.stop();
             }
+            this.paused = false;
             player.reset();
             player.setDataSource(this.filePath);
             player.prepare();
@@ -69,6 +72,13 @@ public class SingleFileAudioPlayer implements IPlayer {
         if (player.isPlaying()) {
             player.pause();
         }
+        this.paused = true;
+    }
+
+    @Override
+    public void resume() {
+        player.start();
+        paused = false;
     }
 
     @Override
@@ -77,5 +87,10 @@ public class SingleFileAudioPlayer implements IPlayer {
         if (player.isPlaying()) {
             player.stop();
         }
+        paused = false;
+    }
+
+    public boolean isPaused() {
+        return paused;
     }
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/components/PlaybarFragment.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/components/PlaybarFragment.java
@@ -10,13 +10,14 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+import android.widget.TextView;
 
 import com.lastcrusade.soundstream.R;
-import com.lastcrusade.soundstream.audio.SingleFileAudioPlayer;
+import com.lastcrusade.soundstream.model.SongMetadata;
 import com.lastcrusade.soundstream.service.PlaylistService;
+import com.lastcrusade.soundstream.service.PlaylistService.PlaylistServiceBinder;
 import com.lastcrusade.soundstream.service.ServiceLocator;
 import com.lastcrusade.soundstream.service.ServiceNotBoundException;
-import com.lastcrusade.soundstream.service.PlaylistService.PlaylistServiceBinder;
 import com.lastcrusade.soundstream.util.BroadcastRegistrar;
 import com.lastcrusade.soundstream.util.IBroadcastActionHandler;
 
@@ -28,6 +29,8 @@ public class PlaybarFragment extends Fragment {
     
     private ServiceLocator<PlaylistService> playlistServiceLocator;
     ImageButton playPause;
+
+    private TextView songTitle;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -48,6 +51,8 @@ public class PlaybarFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
         View view =  inflater.inflate(R.layout.fragment_playbar, container, false);
+        
+        songTitle = (TextView) view.findViewById(R.id.text_now_playing);
         playPause = ((ImageButton) view.findViewById(R.id.btn_play_pause));
 
         playPause.setOnClickListener(new OnClickListener() {
@@ -108,11 +113,12 @@ public class PlaybarFragment extends Fragment {
     private void registerReceivers() {
         this.registrar = new BroadcastRegistrar();
         this.registrar
-            .addAction(SingleFileAudioPlayer.ACTION_SONG_FINISHED, new IBroadcastActionHandler() {
+            .addAction(PlaylistService.ACTION_SONG_PLAYING, new IBroadcastActionHandler() {
                 
                 @Override
                 public void onReceiveAction(Context context, Intent intent) {
-                    setPlayImage();
+                    SongMetadata song = intent.getParcelableExtra(PlaylistService.EXTRA_SONG);
+                    songTitle.setText(song.getTitle());
                 }
             })
             .addAction(PlaylistService.ACTION_PLAYING_AUDIO, new IBroadcastActionHandler() {

--- a/SoundStream/src/com/lastcrusade/soundstream/service/PlaylistService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/PlaylistService.java
@@ -26,7 +26,7 @@ import com.lastcrusade.soundstream.util.Toaster;
  * This service is responsible for holding the play queue and sending songs to
  * the SingleFileAudioPlayer
  */
-public class PlaylistService extends Service implements IPlayer {
+public class PlaylistService extends Service {
 
     /**
      * Broadcast action sent when the Audio Player service is paused.
@@ -51,6 +51,9 @@ public class PlaylistService extends Service implements IPlayer {
      * Broadcast action sent when the playlist gets updated
      */
     public static final String ACTION_PLAYLIST_UPDATED = PlaylistService.class + ".action.PlaylistUpdated";
+
+    public static final String ACTION_SONG_PLAYING     = PlaylistService.class + ".action.SongPlaying";
+    public static final String EXTRA_SONG              = PlaylistService.class + ".extra.Song";
 
     private static final String TAG = PlaylistService.class.getName();
 
@@ -110,10 +113,11 @@ public class PlaylistService extends Service implements IPlayer {
 
             @Override
             public void onReceiveAction(Context context, Intent intent) {
+                // automatically play the next song, but only if we're not paused
                 mPlaylist.moveNext();
-                // TODO: Right now, we don't move automatically to the next song.
-                // Until we make that change, this is appropriate
-                ((CustomApp)getApplication()).getMessagingService().sendPlayStatusMessage("Pause");
+                if (!thePlayer.isPaused()) {
+                    play();
+                }
                 new BroadcastIntent(ACTION_PLAYLIST_UPDATED).send(PlaylistService.this);
             }
         })
@@ -159,35 +163,47 @@ public class PlaylistService extends Service implements IPlayer {
         this.registrar.unregister();
     }
   
-    @Override
     public boolean isPlaying() {
         return this.thePlayer.isPlaying();
     }
 
-    @Override
     public void play() {
-        if(isLocalPlayer()) {
-            if (mPlaylist.size() > 0){
-                setSong(mPlaylist.getNextSong());
-                ((CustomApp)getApplication()).getMessagingService().sendPlayStatusMessage("Play");
-            } else {
-                Toaster.iToast(this, getString(R.string.playlist_empty));
-                return; //SECOND RETURN PATH that makes the code nicer
+        if (this.thePlayer.isPaused()) {
+            this.thePlayer.resume();
+        } else {
+            if(isLocalPlayer()) {
+                playLocal();
             }
+            //we have stuff to play...play it and send a notification
+            this.thePlayer.play();
         }
-        //we have stuff to play...play it and send a notification
-        this.thePlayer.play();
         new BroadcastIntent(ACTION_PLAYING_AUDIO).send(this);
     }
 
-    @Override
+    /**
+     * Helper method to manage all of the things we need to do to play a
+     * song locally (e.g. on the host).
+     */
+    private void playLocal() {
+        if (mPlaylist.size() > 0){
+            SongMetadata song = mPlaylist.getNextSong();
+            setSong(song);
+            new BroadcastIntent(ACTION_SONG_PLAYING)
+                .putExtra(EXTRA_SONG, song)
+                .send(this);
+            ((CustomApp)getApplication()).getMessagingService().sendPlayStatusMessage("Play");
+        } else {
+            Toaster.iToast(this, getString(R.string.playlist_empty));
+            return; //SECOND RETURN PATH that makes the code nicer
+        }
+    }
+
     public void pause() {
         this.thePlayer.pause();
         ((CustomApp)getApplication()).getMessagingService().sendPlayStatusMessage("Pause");
         new BroadcastIntent(ACTION_PAUSED_AUDIO).send(this);
     }
 
-    @Override
     public void skip() {
         this.thePlayer.skip();
         if (isLocalPlayer()) {


### PR DESCRIPTION
This was foundational, before I could tackle transfer song.  I also fixed the pause/resume functionality so it doesnt restart the song, and added a broadcast intent for the current song, and placed the title in the playbar fragment.  We can further style it however we like.
