### PR TITLE
Bug fixes

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/net/AcceptThread.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/net/AcceptThread.java
@@ -55,6 +55,8 @@ public abstract class AcceptThread extends AsyncTask<Void, Void, BluetoothSocket
             Log.i(TAG, "Connection accepted");
         } catch (IOException e) {
             Log.e(TAG, "Unable to accept connection", e);
+        } finally {
+            cancel();
         }
         return socket;
     }

--- a/SoundStream/src/com/lastcrusade/soundstream/net/message/Messenger.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/net/message/Messenger.java
@@ -102,13 +102,12 @@ public class Messenger {
     public boolean deserializeMessage(InputStream input) throws IOException {
         
         boolean processed = false;
-        //read all we can...
-        do {
-            //NOTE: this is so input.read can block, and will throw an exception when the connection
-            // goes down.  this is the only way we'll get a notification of a downed client
-            int read = input.read();
-            inputBuffer.write(read);
-        } while (input.available() > 0);
+        //read one byte at a time...we want to make sure we run thru the logic below after each byte
+        // so we don't hold a message in inputBuffer while waiting for the next byte to come in
+        //NOTE: this is so input.read can block, and will throw an exception when the connection
+        // goes down.  this is the only way we'll get a notification of a downed client
+        int read = input.read();
+        inputBuffer.write(read);
 
         //if we need to, consume the message length (to make sure we read until we have a complete message)
         if (this.messageLength <= 0 && inputBuffer.size() >= SIZE_LEN) {
@@ -155,15 +154,8 @@ public class Messenger {
                 //otherwise, it's a WTF
                 Log.wtf(TAG, "Received message '" + messageName + "', but it does not implement IMessage");
             }
-        } catch (InstantiationException e) {
-            
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-            
+        } catch (Exception e) {
+            Log.wtf(TAG, e);
         } finally {
             //consume this message either way
             int bufferLen = inputBuffer.size();

--- a/SoundStream/src/com/lastcrusade/soundstream/net/message/Messenger.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/net/message/Messenger.java
@@ -92,8 +92,8 @@ public class Messenger {
      * Only one received message may be held at a time, so be prepared to call getReceivedMessage if this
      * method returns true.
      * 
-     * This is designed to not block if data is unavailable, but it may block if InputStream blocks on read,
-     *  and doesn't support available properly
+     * This is designed to block until a full message is received, and will throw an exception if the
+     * socket is closed unexpectedly.
      * 
      * @param input
      * @return
@@ -102,26 +102,29 @@ public class Messenger {
     public boolean deserializeMessage(InputStream input) throws IOException {
         
         boolean processed = false;
-        //read one byte at a time...we want to make sure we run thru the logic below after each byte
-        // so we don't hold a message in inputBuffer while waiting for the next byte to come in
-        //NOTE: this is so input.read can block, and will throw an exception when the connection
-        // goes down.  this is the only way we'll get a notification of a downed client
-        int read = input.read();
-        inputBuffer.write(read);
-
-        //if we need to, consume the message length (to make sure we read until we have a complete message)
-        if (this.messageLength <= 0 && inputBuffer.size() >= SIZE_LEN) {
-            byte[] bytes = inputBuffer.toByteArray();
-            ByteBuffer bb = ByteBuffer.wrap(bytes, 0, SIZE_LEN);
-            //this actually consumes the first 4 bytes (removes it from the stream)
-            inputBuffer.reset();
-            inputBuffer.write(bytes, SIZE_LEN, bytes.length - SIZE_LEN);
-            this.messageLength = bb.getInt();
-        }
-        //check to see if we can process this message
-        if (this.messageLength > 0 && inputBuffer.size() >= this.messageLength) {
-            processed = processAndConsumeMessage();
-        }
+        do {
+            //read one byte at a time...we want to make sure we run thru the logic below after each byte
+            // so we don't hold a message in inputBuffer while waiting for the next byte to come in
+            //NOTE: this is so input.read can block, and will throw an exception when the connection
+            // goes down.  this is the only way we'll get a notification of a downed client
+            int read = input.read();
+            inputBuffer.write(read);
+    
+            //if we need to, consume the message length (to make sure we read until we have a complete message)
+            if (this.messageLength <= 0 && inputBuffer.size() >= SIZE_LEN) {
+                byte[] bytes = inputBuffer.toByteArray();
+                ByteBuffer bb = ByteBuffer.wrap(bytes, 0, SIZE_LEN);
+                //this actually consumes the first 4 bytes (removes it from the stream)
+                inputBuffer.reset();
+                inputBuffer.write(bytes, SIZE_LEN, bytes.length - SIZE_LEN);
+                this.messageLength = bb.getInt();
+            }
+            //check to see if we can process this message
+            if (this.messageLength > 0 && inputBuffer.size() >= this.messageLength) {
+                processed = processAndConsumeMessage();
+            }
+            //loop back around if we havent processed a message yet
+        } while (!processed);
         return processed;
     }
     


### PR DESCRIPTION
Two network bug fixes:

There is a bug when reconnecting a guest after a host has gone down and come back up...this lets the guest reconnect w/o reopening the app.  The fix is to cancel the server socket after a successful connection.

There is a bug when receiving a bunch of messages that was introduced when I added the blocking read call to Messenger.  Messages were getting stuck in the input buffer, and not processed until the next byte was received...as a result, all messages were received late.  The fix was to remove the do...while loop, and make sure we run thru the message check/processing after each received byte.
