### PR TITLE
Added bash script to add GPL statement to the top of every source file

### DIFF
--- a/docs/copyrightJava.txt
+++ b/docs/copyrightJava.txt
@@ -16,3 +16,4 @@
  * You should have received a copy of the GNU General Public License
  * along with SoundStream.  If not, see <http://www.gnu.org/licenses/>.
  */
+

--- a/docs/copyrightXML.txt
+++ b/docs/copyrightXML.txt
@@ -15,3 +15,4 @@
     
     You should have received a copy of the GNU General Public License
     along with SoundStream.  If not, see <http://www.gnu.org/licenses/>. -->
+

--- a/utilities/addGPL.sh
+++ b/utilities/addGPL.sh
@@ -47,3 +47,12 @@ do
 		cat ../docs/copyrightJava.txt $i > $i.new && mv $i.new $i
 	fi
 done
+
+# Edge case: CustomApp.java and CoreActivity.java
+for i in ../SoundStream*/src/com/lastcrusade/soundstream/*.java
+do
+	if ! grep -q Copyright\ 2013\ The\ Last\ Crusade\ ContactLastCrusade@gmail.com $i
+	then
+		cat ../docs/copyrightJava.txt $i > $i.new && mv $i.new $i
+	fi
+done

--- a/utilities/addGPL.sh
+++ b/utilities/addGPL.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This script is designed to add our GPL statement to the top of all of our
+# source files
+
+# Java source files
+for i in ../SoundStream*/src/com/lastcrusade/soundstream/*/*.java
+do
+	if ! grep -q Copyright\ 2013\ The\ Last\ Crusade\ ContactLastCrusade@gmail.com $i
+	then
+		cat ../docs/copyrightJava.txt $i > $i.new && mv $i.new $i
+	fi
+done
+
+# XML source files
+for i in ../SoundStream*/res/*/*.xml
+do
+	if ! grep -q Copyright\ 2013\ The\ Last\ Crusade\ ContactLastCrusade@gmail.com $i
+	then
+		cat ../docs/copyrightXML.txt $i > $i.new && mv $i.new $i
+	fi
+done
+
+# Edge case: /net/message
+for i in ../SoundStream*/src/com/lastcrusade/soundstream/*/*/*.java
+do
+	if ! grep -q Copyright\ 2013\ The\ Last\ Crusade\ ContactLastCrusade@gmail.com $i
+	then
+		cat ../docs/copyrightJava.txt $i > $i.new && mv $i.new $i
+	fi
+done
+
+# Edge case: AndroidManifest.xml and build.xml
+for i in ../SoundStream*/*.xml
+do
+	if ! grep -q Copyright\ 2013\ The\ Last\ Crusade\ ContactLastCrusade@gmail.com $i
+	then
+		cat ../docs/copyrightXML.txt $i > $i.new && mv $i.new $i
+	fi
+done
+
+# Edge case: SoundStream-test Parcelable.java
+for i in ../SoundStream*/src/android/os/*.java
+do
+	if ! grep -q Copyright\ 2013\ The\ Last\ Crusade\ ContactLastCrusade@gmail.com $i
+	then
+		cat ../docs/copyrightJava.txt $i > $i.new && mv $i.new $i
+	fi
+done


### PR DESCRIPTION
Added newlines to the end of copyrightJava.txt and copyrightXML.txt to make things pretty. 

Wrote a bash script to add our GPL statement to the top of all of our source files.

I've tested the script on a dummy checkout of our source and it works. I'm putting this pull request up now to make sure I haven't missed any of our source files. Actually running the script and pulling in the changes will be left for another pull request.
