### PR TITLE
band-aid fix for the rotation issue

### DIFF
--- a/SoundStream/AndroidManifest.xml
+++ b/SoundStream/AndroidManifest.xml
@@ -9,8 +9,16 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
-    <application android:allowBackup="true" android:icon="@drawable/soundstream_launcher" android:label="@string/app_name" android:name=".CustomApp" android:theme="@style/AppTheme">
-        <activity android:label="@string/app_name" android:name=".CoreActivity">
+    <application android:allowBackup="true"
+                 android:icon="@drawable/soundstream_launcher"
+                 android:label="@string/app_name"
+                 android:name=".CustomApp"
+                 android:theme="@style/AppTheme">
+        <!-- TODO: configChanges IS A BAND-AID FIX. SHOULD BE REPLACED WITH OnSavedInstanceState
+        IN THE FRAGMENT ONCE WE FIGURE OUT THE LIFECYCLE WEIRDNESS-->
+        <activity android:label="@string/app_name"
+                  android:name=".CoreActivity"
+                  android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
This is not the correct way to fix this issue, but it will get us through to the alpha.

The correct way to handle rotation is to save the necessary data in an overridden onSaveInstanceState method and pull them out of the bundle in onCreate. However, if we try to do it this way right now, we don't have a Bundle when onCreate is called after the rotation.  The Bundle is created correctly but onCreate is called twice for some reason with the Bundle  missing in the second calling of onCreate.
