### PR TITLE
APlaylistEntryMessage base test

### DIFF
--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/APlaylistEntrySerializationTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/APlaylistEntrySerializationTest.java
@@ -1,0 +1,23 @@
+package com.lastcrusade.soundstream.net.message;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Generic baseclass for APlaylistEntryMessage tests.
+ * 
+ * @author Jesse Rosalia
+ *
+ * @param <T>
+ */
+public class APlaylistEntrySerializationTest<T extends APlaylistEntryMessage>
+    extends SerializationTest<T> {
+
+    public T testSerializeMessage(T preSer) throws Exception {
+        T postSer = super.testSerializeMessage(preSer);
+        //check the standard information in APlaylistEntryMessage
+        assertEquals(preSer.getMacAddress(), postSer.getMacAddress());
+        assertEquals(preSer.getId(),         postSer.getId());
+        //return the new message object
+        return postSer;
+    }
+}

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/APlaylistEntrySerializationTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/APlaylistEntrySerializationTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2013 The Last Crusade ContactLastCrusade@gmail.com
+ * 
+ * This file is part of SoundStream.
+ * 
+ * SoundStream is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * SoundStream is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with SoundStream.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.lastcrusade.soundstream.net.message;
 
 import static org.junit.Assert.assertEquals;

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/AddToPlaylistMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/AddToPlaylistMessageTest.java
@@ -6,13 +6,12 @@ import java.io.IOException;
 
 import org.junit.Test;
 
-public class AddToPlaylistMessageTest extends SerializationTest<AddToPlaylistMessage>{
+public class AddToPlaylistMessageTest
+extends APlaylistEntrySerializationTest<AddToPlaylistMessage>{
 
     @Test
-    public void testSerializeSongStatusMessage() throws Exception {
-        AddToPlaylistMessage preSer  = new AddToPlaylistMessage("Test", 1234);
-        AddToPlaylistMessage postSer = super.testSerializeMessage(preSer);
-        assertEquals(preSer.getMacAddress(), postSer.getMacAddress());
-        assertEquals(preSer.getId(),         postSer.getId());
+    public void testSerializeAddToPlaylistMessage() throws Exception {
+        super.testSerializeMessage(
+                new AddToPlaylistMessage("Test", 1234));
     }
 }

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/AllMessageTests.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/AllMessageTests.java
@@ -5,12 +5,15 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ AddToPlaylistMessageTest.class, BumpSongOnPlaylistMessageTest.class,
-        ConnectGuestsMessageTest.class, FindNewGuestsMessageTest.class,
-        FoundGuestsMessageTest.class, LibraryMessageTest.class,
-        MessengerTest.class, PauseMessageTest.class, PlayMessageTest.class,
-        RemoveFromPlaylistMessageTest.class, RequestSongMessageTest.class,
-        SkipMessageTest.class, UserListMessageTest.class, PlaylistMessageTest.class })
+@SuiteClasses({ AddToPlaylistMessageTest.class,
+        BumpSongOnPlaylistMessageTest.class, ConnectGuestsMessageTest.class,
+        FindNewGuestsMessageTest.class, FoundGuestsMessageTest.class,
+        LibraryMessageTest.class, MessengerTest.class, PauseMessageTest.class,
+        PlaylistMessageTest.class, PlayMessageTest.class,
+        PlayStatusMessageTest.class, RemoveFromPlaylistMessageTest.class,
+        RequestSongMessageTest.class, SkipMessageTest.class,
+        SongStatusMessageTest.class, TransferSongMessageTest.class,
+        UserListMessageTest.class })
 public class AllMessageTests {
 
 }

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/BumpSongOnPlaylistMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/BumpSongOnPlaylistMessageTest.java
@@ -6,13 +6,12 @@ import java.io.IOException;
 
 import org.junit.Test;
 
-public class BumpSongOnPlaylistMessageTest extends SerializationTest<BumpSongOnPlaylistMessage>{
+public class BumpSongOnPlaylistMessageTest
+extends APlaylistEntrySerializationTest<BumpSongOnPlaylistMessage>{
 
     @Test
-    public void testSerializeSongStatusMessage() throws Exception {
-        BumpSongOnPlaylistMessage preSer  = new BumpSongOnPlaylistMessage("Test", 1234);
-        BumpSongOnPlaylistMessage postSer = super.testSerializeMessage(preSer);
-        assertEquals(preSer.getMacAddress(), postSer.getMacAddress());
-        assertEquals(preSer.getId(),         postSer.getId());
+    public void testSerializeBumpSongOnPlaylistMessage() throws Exception {
+        super.testSerializeMessage(
+                new BumpSongOnPlaylistMessage("Test", 1234));
     }
 }

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/PlayStatusMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/PlayStatusMessageTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2013 The Last Crusade ContactLastCrusade@gmail.com
+ * 
+ * This file is part of SoundStream.
+ * 
+ * SoundStream is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * SoundStream is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with SoundStream.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.lastcrusade.soundstream.net.message;
 
 import static org.junit.Assert.fail;

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/PlayStatusMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/PlayStatusMessageTest.java
@@ -1,9 +1,6 @@
 package com.lastcrusade.soundstream.net.message;
 
-import static com.lastcrusade.soundstream.util.CustomAssert.assertSongMetaEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -15,20 +12,21 @@ public class PlayStatusMessageTest extends SerializationTest<PlayStatusMessage> 
     public void testSerializePlayStatusMessage() throws Exception {
         PlayStatusMessage preSerializationPlayStatusMsg = new PlayStatusMessage();
 
-        preSerializationPlayStatusMsg.setString(PlayStatusMessage.PLAY_MESSAGE);
-        preSerializationPlayStatusMsg.setCurrentSong(getSomeSongMetadata());
-        PlayStatusMessage postSerializationPlayStatusMsg = super.testSerializeMessage(preSerializationPlayStatusMsg);
-		
-        // Testing play with song
-        assertEquals(PlayStatusMessage.PLAY_MESSAGE, postSerializationPlayStatusMsg.getString());
-        assertSongMetaEquals(getSomeSongMetadata(), postSerializationPlayStatusMsg.getCurrentSong());
-
-        // Testing pause with song
-        preSerializationPlayStatusMsg.setString(PlayStatusMessage.PAUSE_MESSAGE);
-	    preSerializationPlayStatusMsg.setCurrentSong(getSomeSongMetadata());
-	    postSerializationPlayStatusMsg = super.testSerializeMessage(preSerializationPlayStatusMsg);
-	    assertEquals(PlayStatusMessage.PAUSE_MESSAGE, postSerializationPlayStatusMsg.getString());
-	    assertSongMetaEquals(getSomeSongMetadata(), postSerializationPlayStatusMsg.getCurrentSong());
+//        preSerializationPlayStatusMsg.setString(PlayStatusMessage.PLAY_MESSAGE);
+//        preSerializationPlayStatusMsg.setCurrentSong(getSomeSongMetadata());
+//        PlayStatusMessage postSerializationPlayStatusMsg = super.testSerializeMessage(preSerializationPlayStatusMsg);
+//		
+//        // Testing play with song
+//        assertEquals(PlayStatusMessage.PLAY_MESSAGE, postSerializationPlayStatusMsg.getString());
+//        assertSongMetaEquals(getSomeSongMetadata(), postSerializationPlayStatusMsg.getCurrentSong());
+//
+//        // Testing pause with song
+//        preSerializationPlayStatusMsg.setString(PlayStatusMessage.PAUSE_MESSAGE);
+//	    preSerializationPlayStatusMsg.setCurrentSong(getSomeSongMetadata());
+//	    postSerializationPlayStatusMsg = super.testSerializeMessage(preSerializationPlayStatusMsg);
+//	    assertEquals(PlayStatusMessage.PAUSE_MESSAGE, postSerializationPlayStatusMsg.getString());
+//	    assertSongMetaEquals(getSomeSongMetadata(), postSerializationPlayStatusMsg.getCurrentSong());
+        fail("Need to reimplement");
 	}
 	
 	private SongMetadata getSomeSongMetadata(){

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/RemoveFromPlaylistMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/RemoveFromPlaylistMessageTest.java
@@ -2,17 +2,14 @@ package com.lastcrusade.soundstream.net.message;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-
 import org.junit.Test;
 
-public class RemoveFromPlaylistMessageTest extends SerializationTest<RemoveFromPlaylistMessage>{
+public class RemoveFromPlaylistMessageTest
+extends APlaylistEntrySerializationTest<RemoveFromPlaylistMessage>{
 
     @Test
-    public void testSerializeSongStatusMessage() throws Exception {
-        RemoveFromPlaylistMessage preSer  = new RemoveFromPlaylistMessage("Test", 1234);
-        RemoveFromPlaylistMessage postSer = super.testSerializeMessage(preSer);
-        assertEquals(preSer.getMacAddress(), postSer.getMacAddress());
-        assertEquals(preSer.getId(),         postSer.getId());
+    public void testSerializeRemoveFromPlaylistMessage() throws Exception {
+        super.testSerializeMessage(
+                new RemoveFromPlaylistMessage("Test", 1234));
     }
 }


### PR DESCRIPTION
Pulled generic class APlaylistEntryMessage tests in a test base class, and changed the current playlist messages to use that class.

Commented out and failed PlayStatusMessageTest...this needs to be reimplemented
