### PR TITLE
clear should also set the entryId to zero

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/model/Playlist.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/model/Playlist.java
@@ -57,6 +57,7 @@ public class Playlist {
     public void clear() {
         playedList.clear();
         musicList.clear();
+        lastEntryId = 0;
     }
     
     public PlaylistEntry findEntryBySongAndId(SongMetadata song, int entryId){


### PR DESCRIPTION
This caused the last entry to appear to be transferring for a while
