### PR TITLE
Fixed issue decoding song ids

### DIFF
--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/LibraryMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/LibraryMessageTest.java
@@ -61,7 +61,11 @@ public class LibraryMessageTest extends SerializationTest<LibraryMessage> {
                 new SongMetadata(23, "Toronto Customs Lady", "Aziz Ansari",
                         null, 3423462, "David"), 
                 new SongMetadata(42, "Motley Crue Tour vs. Aziz Tour", "Aziz Ansari",
-                        "Dangerously Delicious", 2346236, null)));
+                        "Dangerously Delicious", 2346236, null),
+                //NOTE: this id is specifically chosen to make sure that readLong/writeLong
+                // will handle encoded bytes that are negative
+                new SongMetadata(59916, "Numbers are Fun", "Jesse and Reid",
+                        "The WTF Tour", 2346236, null)));
         return library;
     }
 }

--- a/SoundStream-test/src/com/lastcrusade/soundstream/net/message/LibraryMessageTest.java
+++ b/SoundStream-test/src/com/lastcrusade/soundstream/net/message/LibraryMessageTest.java
@@ -65,7 +65,8 @@ public class LibraryMessageTest extends SerializationTest<LibraryMessage> {
                 //NOTE: this id is specifically chosen to make sure that readLong/writeLong
                 // will handle encoded bytes that are negative
                 new SongMetadata(59916, "Numbers are Fun", "Jesse and Reid",
-                        "The WTF Tour", 2346236, null)));
+                        "The WTF Tour", 2346236, null)
+            ));
         return library;
     }
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/net/MessageThreadWriter.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/net/MessageThreadWriter.java
@@ -93,9 +93,13 @@ public class MessageThreadWriter {
         qe.messageClass  = message.getClass();
         qe.messageStream = messenger.serializeMessage(message);
         if (LogUtil.isLogAvailable()) {
+            //precompute the expected queue size...this is because the writer thread may quickly pick
+            // up the queue item which, while swell, means the debug output may be confusing
+            int newExpectedQueueSize = queue.size() + 1;
             Log.i(TAG, "Message " + qe.messageNo + " enqueued, it's a "
                         + qe.messageClass.getSimpleName() + ", "
-                        + qe.messageStream.available() + " bytes in length");
+                        + qe.messageStream.available() + " bytes in length, "
+                        + newExpectedQueueSize + " entries in the queue");
         }
         queue.add(qe);
     }

--- a/SoundStream/src/com/lastcrusade/soundstream/net/message/ADataMessage.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/net/message/ADataMessage.java
@@ -62,6 +62,8 @@ public abstract class ADataMessage extends AComplexDataType implements IMessage 
             return null;
         }
     }
+    
+    //TODO: move these into AComplexDataType and use ByteBuffer
 
     protected void writeLong(long value, OutputStream output) throws IOException {
         output.write((int)(value         & 0xFF));
@@ -75,16 +77,30 @@ public abstract class ADataMessage extends AComplexDataType implements IMessage 
     }
 
     protected long readLong(InputStream input) throws IOException {
-    	long value = input.read();
-    	value 	  |= (input.read() << 8);
-    	value 	  |= (input.read() << 16);
-    	value 	  |= (input.read() << 24);
-    	value 	  |= (input.read() << 32);
-    	value 	  |= (input.read() << 40);
-    	value 	  |= (input.read() << 48);
-    	value 	  |= (input.read() << 56);
+    	long value = toInt(input.read());
+    	value 	  |= (toInt(input.read()) << 8);
+    	value 	  |= (toInt(input.read()) << 16);
+    	value 	  |= (toInt(input.read()) << 24);
+    	value 	  |= (toInt(input.read()) << 32);
+    	value 	  |= (toInt(input.read()) << 40);
+    	value 	  |= (toInt(input.read()) << 48);
+    	value 	  |= (toInt(input.read()) << 56);
     	
     	return value;
+    }
+
+    /**
+     * Convert an unsigned byte read from an input stream (held in an int) into
+     * an unsigned number.
+     * 
+     * This is because Java does not have unsigned types, and so bytes that
+     * are > 127 will come in as negative and F everything up.
+     * 
+     * @param read
+     * @return
+     */
+    private int toInt(int read) {
+        return (read & 0xFF);
     }
 
     protected void writeSongMetadata(SongMetadata metadata, OutputStream output) throws IOException{


### PR DESCRIPTION
Fixed issue with decoding IDs with bytes that exceed 127.  Java needs unsigned types, badly.
