### PR TITLE
Fixes for various bugs with audio ducking/focus, and some misc NPEs

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/SoundStreamExternalControlClient.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/SoundStreamExternalControlClient.java
@@ -56,9 +56,31 @@ public class SoundStreamExternalControlClient {
 
     public SoundStreamExternalControlClient(Context context) {
         this.context = context;
+        
+        buildClient();
+        //we want the receivers even before we've registered the client,
+        // to accumulate state
         registerReceivers();
     }
     
+    /**
+     * 
+     */
+    private void buildClient() {
+        Class<?> receiverClass = ExternalMusicControlHandler.class;
+        this.mediaButtonEventReceiver = new ComponentName(
+                context.getPackageName(),
+                receiverClass.getName());
+        // build the PendingIntent for the remote control client
+        Intent mediaButtonIntent = new Intent(Intent.ACTION_MEDIA_BUTTON);
+        mediaButtonIntent.setComponent(mediaButtonEventReceiver);
+        PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, 0);
+        // create and register the remote control client
+        //NOTE: the client is created in all cases, but we call a method to
+        // set up and register it...this is so we can gracefully handle older versions of android.
+        mRemoteControlClientCompat = new RemoteControlClientCompat(mediaPendingIntent);
+    }
+
     public void registerClient() {
         registerRemoteControlClient();
         updateRemoteControlClient();
@@ -106,20 +128,8 @@ public class SoundStreamExternalControlClient {
     }
 
     private void registerRemoteControlClient() {
-        Class<?> receiverClass = ExternalMusicControlHandler.class;
-        this.mediaButtonEventReceiver = new ComponentName(
-                context.getPackageName(),
-                receiverClass.getName());
         AudioManager audioManager = (AudioManager) this.context.getSystemService(Context.AUDIO_SERVICE);
         audioManager.registerMediaButtonEventReceiver(mediaButtonEventReceiver);
-        // build the PendingIntent for the remote control client
-        Intent mediaButtonIntent = new Intent(Intent.ACTION_MEDIA_BUTTON);
-        mediaButtonIntent.setComponent(mediaButtonEventReceiver);
-        PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, 0);
-        // create and register the remote control client
-        //NOTE: the client is created in all cases, but we call a method to
-        // set up and register it...this is so we can gracefully handle older versions of android.
-        mRemoteControlClientCompat = new RemoteControlClientCompat(mediaPendingIntent);
         registerRemoteControlClientCompat(audioManager);
     }
 

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
@@ -37,7 +37,7 @@ public class AudioPlayerWithEvents implements IPlayer {
 
     private static final String TAG = AudioPlayerWithEvents.class.getSimpleName();
 
-    private static final int DUCK_TIMER_DELAY = 2000;
+    private static final int DUCK_TIMER_DELAY_MS = 2000;
 
     private IPlayer player;
     private Context context;
@@ -137,7 +137,7 @@ public class AudioPlayerWithEvents implements IPlayer {
     }
 
     /**
-     * Handle loss of audio focus.  In the both permanent case,
+     * Handle loss of audio focus.  In the the case of permanent loss,
      * we want to unregister our external control client and pause the music.
      * 
      * In all cases, pause the music and indicate that the music can be resumed
@@ -229,7 +229,7 @@ public class AudioPlayerWithEvents implements IPlayer {
             @Override
             public void run() {
                 if (LogUtil.isLogAvailable()) {
-                    Log.d(TAG, "Duck timer executed...something's wrong.  Resetting audio focus and unducking volumne..");
+                    Log.d(TAG, "Duck timer executed...something's wrong.  Resetting audio focus and unducking volume..");
                 }
                 //in this case, something is stuck...rerequest audio focus
                 //NOTE: this is important, because if we didn't receive the AUDIOFOCUS_GAIN
@@ -240,7 +240,7 @@ public class AudioPlayerWithEvents implements IPlayer {
                 unduck();
             }
             
-        }, DUCK_TIMER_DELAY);
+        }, DUCK_TIMER_DELAY_MS);
     }
     /**
      * Duck the volume of the player, if the player supports
@@ -289,7 +289,7 @@ public class AudioPlayerWithEvents implements IPlayer {
     /**
      * Private helper method that will pause the audio, regardless of who calls it.
      * 
-     * Callers can then decide whehter its appropriate to pause on their own terms. 
+     * Callers can then decide whether its appropriate to pause on their own terms. 
      * 
      */
     private void doPause() {

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
@@ -212,7 +212,9 @@ public class AudioPlayerWithEvents implements IPlayer {
      * 
      */
     private void cancelDuckTimer() {
-        this.duckTimer.cancel();
+        if (this.duckTimer != null) {
+            this.duckTimer.cancel();
+        }
         this.duckTimer = null;
     }
 

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
@@ -19,6 +19,9 @@
 
 package com.lastcrusade.soundstream.audio;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.AudioManager.OnAudioFocusChangeListener;
@@ -34,13 +37,19 @@ public class AudioPlayerWithEvents implements IPlayer {
 
     private static final String TAG = AudioPlayerWithEvents.class.getSimpleName();
 
+    private static final int DUCK_TIMER_DELAY = 2000;
+
     private IPlayer player;
     private Context context;
     private IDuckable duckable;
 
     private SoundStreamExternalControlClient externalControlClient;
 
-    private boolean registered;
+    private boolean canAudioFocusResume;
+
+    private OnAudioFocusChangeListener focusChangeListener;
+
+    private Timer duckTimer;
 
     //NOTE: this is static, because music focus is a global attribute that belongs to the phone
     //TODO: this may be better off put in a global settings object...
@@ -51,55 +60,43 @@ public class AudioPlayerWithEvents implements IPlayer {
         this.duckable = ClassUtils.getIfAvailable(player, IDuckable.class);
         this.context = context;
         this.externalControlClient = new SoundStreamExternalControlClient(this.context);
-        this.registered = false;
         hasFocus = false;
+        
+        this.focusChangeListener = new OnAudioFocusChangeListener() {
+            
+            @Override
+            public void onAudioFocusChange(int focusChange) {
+                handleAudioFocusChange(focusChange);
+            }
+        };
     }
     
     private void registerExternalControlClient() {
         externalControlClient.registerClient();
-        this.registered = true;
     }
 
     private void unregisterExternalControlClient() {
-        this.registered = false;
         externalControlClient.unregisterClient();
     }
-    
-    private boolean isExternalControlClientRegistered() {
-        return this.registered;
+
+    private void releaseAudio() {
+        AudioManager myAudioManager = (AudioManager) this.context.getSystemService(Context.AUDIO_SERVICE);
+        myAudioManager.abandonAudioFocus(this.focusChangeListener);
+        //unregister the external control client when focus is lost, as per best practice
+        unregisterExternalControlClient();
+        hasFocus = false;
     }
 
     private void requestAudio() {
         //NOTE: we need to request the audio for the remote controls to work, but
         // we also want to handle things like audio ducking and pausing here.
         AudioManager myAudioManager = (AudioManager) this.context.getSystemService(Context.AUDIO_SERVICE);
+        //only request audio focus if we don't already have it
         if (!hasFocus) {
-            int response = myAudioManager.requestAudioFocus(new OnAudioFocusChangeListener() {
-    
-                @Override
-                public void onAudioFocusChange(int focusChange) {
-                    //TODO: duck audio or pause in other cases where focus has changed.
-                    switch (focusChange) {
-                    //handle loss of focus, which includes when a phonecall is coming in
-                    case AudioManager.AUDIOFOCUS_LOSS:
-                    case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                        handleAudioFocusLoss(focusChange == AudioManager.AUDIOFOCUS_LOSS);
-                        hasFocus = false;
-                        break;
-                    case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                        handleAudioFocusCanDuck();
-                        //NOTE: this will not change the audio focus permanently, so
-                        // we dont change hasFocus
-                        break;
-                    case AudioManager.AUDIOFOCUS_GAIN:
-                    case AudioManager.AUDIOFOCUS_GAIN_TRANSIENT:
-                        handleAudioFocusReturned(focusChange == AudioManager.AUDIOFOCUS_GAIN);
-                        hasFocus = true;
-                        break;
-                    }
-                }
-
-            }, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+            int response = myAudioManager.requestAudioFocus(
+                    this.focusChangeListener,
+                    AudioManager.STREAM_MUSIC,
+                    AudioManager.AUDIOFOCUS_GAIN);
             hasFocus = response == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
             if (hasFocus) {
                 registerExternalControlClient();
@@ -107,9 +104,44 @@ public class AudioPlayerWithEvents implements IPlayer {
         }
     }
 
+
     /**
-     * Handle loss of audio focus.  In both permanent and temporary cases,
+     * Called from the AudioFocusChangeListener to handle the different stages
+     * of audio focus.
+     * 
+     * @param focusChange
+     */
+    private void handleAudioFocusChange(int focusChange) {
+        //TODO: duck audio or pause in other cases where focus has changed.
+        switch (focusChange) {
+        //handle loss of focus, which includes when a phonecall is coming in
+        case AudioManager.AUDIOFOCUS_LOSS:
+        case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+            handleAudioFocusLoss(focusChange == AudioManager.AUDIOFOCUS_LOSS);
+            break;
+        case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+            handleAudioFocusCanDuck();
+            //NOTE: this will not change the audio focus permanently, so
+            // we dont change hasFocus
+            break;
+        case AudioManager.AUDIOFOCUS_GAIN:
+        case AudioManager.AUDIOFOCUS_GAIN_TRANSIENT:
+            handleAudioFocusReturned(focusChange == AudioManager.AUDIOFOCUS_GAIN);
+            break;
+        default:
+            if (LogUtil.isLogAvailable()) {
+                Log.w(TAG, String.format("Unhandled focus change event %d", focusChange));
+            }
+
+        }
+    }
+
+    /**
+     * Handle loss of audio focus.  In the both permanent case,
      * we want to unregister our external control client and pause the music.
+     * 
+     * In all cases, pause the music and indicate that the music can be resumed
+     * 
      * 
      * No further cleanup is required for permanent loss, as the user may come
      * back and use the app and expect state to be maintained.
@@ -120,10 +152,13 @@ public class AudioPlayerWithEvents implements IPlayer {
         if (LogUtil.isLogAvailable()) {
             Log.d(TAG, String.format("Audio focus lost%s", permanent ? "" : " (transient)"));
         }
-        //unregister the external control client when focus is lost, as per best practice
-        unregisterExternalControlClient();
-        //NOTE: this calls the the pause method directly, because we want instant action.
-        pause();
+        //we've permanently lost audio focus...unregister thyself
+        if (permanent) {
+            releaseAudio();
+        }
+        
+        canAudioFocusResume = true;
+        doPause();
     }
 
     /**
@@ -136,9 +171,14 @@ public class AudioPlayerWithEvents implements IPlayer {
         if (LogUtil.isLogAvailable()) {
             Log.d(TAG, "Audio focus lost (can duck)");
         }
+        canAudioFocusResume = false;
         duck();
+        startDuckTimer();
         //NOTE: don't touch the external client
         //...we have technically not lost focus
+        if (LogUtil.isLogAvailable()) {
+            Log.d(TAG, "Ducking complete");
+        }
     }
 
     /**
@@ -150,15 +190,56 @@ public class AudioPlayerWithEvents implements IPlayer {
         if (LogUtil.isLogAvailable()) {
             Log.d(TAG, String.format("Audio focus returned%s", permanent ? "" : " (transient)"));
         }
+        cancelDuckTimer();
         //register the external control client when we gain focus
         // but only if we're unregistered
-        if (!isExternalControlClientRegistered()) {
-            registerExternalControlClient();
+        if (permanent) {
+            requestAudio();
         }
         unduck();
-        resume();
+        //only resume if we can resume from audio focus events
+        //...currently, this is only true if we've lost audio focus while playing.
+        if (canAudioFocusResume) {
+            if (LogUtil.isLogAvailable()) {
+                Log.d(TAG, "Resuming audio playback");
+            }
+            canAudioFocusResume = false;
+            doResume();
+        }
     }
 
+    /**
+     * 
+     */
+    private void cancelDuckTimer() {
+        this.duckTimer.cancel();
+        this.duckTimer = null;
+    }
+
+    private void startDuckTimer() {
+        if (this.duckTimer != null) {
+            cancelDuckTimer();
+        }
+
+        this.duckTimer = new Timer();
+        this.duckTimer.schedule(new TimerTask() {
+
+            @Override
+            public void run() {
+                if (LogUtil.isLogAvailable()) {
+                    Log.d(TAG, "Duck timer executed...something's wrong.  Resetting audio focus and unducking volumne..");
+                }
+                //in this case, something is stuck...rerequest audio focus
+                //NOTE: this is important, because if we didn't receive the AUDIOFOCUS_GAIN
+                // focus change, we do NOT have audio focus, and therefore
+                // will not play nice with the other audio apps on the phone
+                hasFocus = false;
+                requestAudio();
+                unduck();
+            }
+            
+        }, DUCK_TIMER_DELAY);
+    }
     /**
      * Duck the volume of the player, if the player supports
      * audio ducking.
@@ -192,19 +273,42 @@ public class AudioPlayerWithEvents implements IPlayer {
     @Override
     public void play() {
         requestAudio();
+        unduck(); //return to full volume
         this.player.play();
         new BroadcastIntent(PlaylistService.ACTION_PLAYING_AUDIO).send(this.context);
     }
 
     @Override
     public void pause() {
+        canAudioFocusResume = false;
+        doPause();
+    }
+    
+    /**
+     * Private helper method that will pause the audio, regardless of who calls it.
+     * 
+     * Callers can then decide whehter its appropriate to pause on their own terms. 
+     * 
+     */
+    private void doPause() {
         this.player.pause();
         new BroadcastIntent(PlaylistService.ACTION_PAUSED_AUDIO).send(this.context);
     }
 
     @Override
     public void resume() {
+        canAudioFocusResume = false;
+        doResume();
+    }
+    
+    /**
+     * Private helper method that will resume the audio, regardless of who calls it.
+     *
+     * Callers can then decide whether its appropriate to resume on their own terms.
+     */
+    private void doResume() {
         requestAudio();
+        unduck(); //return to full volume
         this.player.resume();
         new BroadcastIntent(PlaylistService.ACTION_PLAYING_AUDIO).send(this.context);
     }

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
@@ -165,9 +165,11 @@ public class SingleFileAudioPlayer implements IPlayer, IDuckable {
         new BroadcastIntent(PlaylistService.ACTION_PAUSED_AUDIO).send(this.context);
         try {
             //FIXME this causes crashes
-            this.messagingService
-                .getService()
-                .sendPlayStatusMessage(this.entry, false);
+            if (this.entry != null) {
+                this.messagingService
+                    .getService()
+                    .sendPlayStatusMessage(this.entry, false);
+            }
         } catch (ServiceNotBoundException e) {
             Log.wtf(TAG, e);
         }


### PR DESCRIPTION
Fixed problem where audio was being unpaused when a user pauses the song..., and an audio event from another app happens.  In the process, I found a really weird
bug with Android Audio focus...if two or more other apps request audiofocus gain
can duck at or around the same time, audio focus may not always be returned to
SoundStream.  This is fixed by using a timer task, scheduled 2 seconds out from
when we got the can_duck notification, and will re-grab audio focus and unduck
the volume manually

modified external control client to not create the client immediately (but not
register it).  This is useful because it means the client object is never null,
which fixes a crash caused by pressing play very quickly after adding your first
song.

added test for null in SingleFileAudioPlayer to fix the same kind of bug.
