### PR TITLE
Fixed numerous issues with sharing state across the network.

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/audio/IPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/IPlayer.java
@@ -32,6 +32,13 @@ public interface IPlayer {
 
     public boolean isPlaying();
     
+    /**
+     * Cancel playback through this player.  This may involve releasing audio focus
+     * and freeing resources.
+     * 
+     */
+    public void cancel();
+    
     public void play();
 
     public void pause();

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/RemoteAudioPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/RemoteAudioPlayer.java
@@ -51,6 +51,11 @@ public class RemoteAudioPlayer implements IPlayer {
     }
 
     @Override
+    public void cancel() {
+        //NO OP
+    }
+
+    @Override
     public boolean isPaused() {
         return this.paused;
     }
@@ -108,21 +113,24 @@ public class RemoteAudioPlayer implements IPlayer {
     
     private void registerReceivers() {
     	this.registrar = new BroadcastRegistrar();
-    	this.registrar.addLocalAction(MessagingService.ACTION_PLAY_STATUS_MESSAGE,
-    			new IBroadcastActionHandler() {
-			
-			@Override
-			public void onReceiveAction(Context context, Intent intent) {
-				playing = intent.getBooleanExtra(MessagingService.EXTRA_IS_PLAYING, false);
-				if(playing) {
-				    paused = false;
-					new LocalBroadcastIntent(PlaylistService.ACTION_PLAYING_AUDIO).send(context);
-				}
-				else {
-				    paused = true;
-					new LocalBroadcastIntent(PlaylistService.ACTION_PAUSED_AUDIO).send(context);
-				}
-			}
-		}).register(this.context);
+    	//update the internal state when we've received a change
+    	this.registrar
+    	.addLocalAction(PlaylistService.ACTION_PAUSED_AUDIO, new IBroadcastActionHandler() {
+            
+            @Override
+            public void onReceiveAction(Context context, Intent intent) {
+                paused = true;
+                playing = false;
+            }
+        })
+        .addLocalAction(PlaylistService.ACTION_PLAYING_AUDIO, new IBroadcastActionHandler() {
+            
+            @Override
+            public void onReceiveAction(Context context, Intent intent) {
+                paused = false;
+                playing = true;
+            }
+        })
+        .register(this.context);
     }
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
@@ -73,6 +73,11 @@ public class SingleFileAudioPlayer implements IPlayer, IDuckable {
         });
     }
 
+    @Override
+    public void cancel() {
+        //NO OP for now
+    }
+
     /**
      * Set the song path and accompanying metadata to play.
      * 

--- a/SoundStream/src/com/lastcrusade/soundstream/model/Playlist.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/model/Playlist.java
@@ -60,15 +60,27 @@ public class Playlist {
         lastEntryId = 0;
     }
     
-    public PlaylistEntry findEntryBySongAndId(SongMetadata song, int entryId){
+    /**
+     * @param macAddress The address of the device that owns the song.
+     * @param songId The id of the song on the owner device.
+     * @param entryId The playlist entry id.
+     * @return 
+     */
+    public PlaylistEntry findEntryByAddressIdAndEntry(String macAddress, long songId, int entryId) {
         PlaylistEntry found = null;
         for(PlaylistEntry entry: getSongsToPlay()){
-            if(SongMetadataUtils.isTheSameSong(entry, song) && entry.getEntryId() == entryId){
+            if(entry.getMacAddress().equals(macAddress)
+                    && entry.getId() == songId
+                    && entry.getEntryId() == entryId){
                 found = entry;
                 break;
             }
         }
         return found;
+    }
+
+    public PlaylistEntry findEntryBySongAndId(SongMetadata song, int entryId){
+        return findEntryByAddressIdAndEntry(song.getMacAddress(), song.getId(), entryId);
     }
 
     public PlaylistEntry remove(PlaylistEntry entry) {

--- a/SoundStream/src/com/lastcrusade/soundstream/service/MessagingService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/MessagingService.java
@@ -209,6 +209,7 @@ public class MessagingService extends Service implements IMessagingService {
                                 .putExtra(EXTRA_ADDRESS,
                                         message.getMacAddress())
                                 .putExtra(EXTRA_SONG_ID, message.getId())
+                                .putExtra(EXTRA_ENTRY_ID, message.getEntryId())
                                 .send(MessagingService.this);
                     }
                 });

--- a/SoundStream/src/com/lastcrusade/soundstream/service/PlaylistService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/PlaylistService.java
@@ -233,7 +233,9 @@ public class PlaylistService extends Service {
             @Override
             public void onReceiveAction(Context context, Intent intent) {
                 getMessagingService().sendPlaylistMessage(mPlaylist.getSongsToPlay());
-                getMessagingService().sendPlayStatusMessage(currentEntry, mThePlayer.isPlaying());
+                if (currentEntry != null) {
+                    getMessagingService().sendPlayStatusMessage(currentEntry, mThePlayer.isPlaying());
+                }
             }
         })
         .addLocalAction(MessagingService.ACTION_PLAY_STATUS_MESSAGE, new IBroadcastActionHandler() {

--- a/SoundStream/src/com/lastcrusade/soundstream/util/RemoteControlClientCompat.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/util/RemoteControlClientCompat.java
@@ -409,7 +409,10 @@ public class RemoteControlClientCompat {
      */
     public void unregister() {
         if (sHasRemoteControlAPIs) {
-            RemoteControlHelper.unregisterRemoteControlClient(mRegisteredAudioManager, this);
+            //only unregister if we were previously registered
+            if (mRegisteredAudioManager != null) {
+                RemoteControlHelper.unregisterRemoteControlClient(mRegisteredAudioManager, this);
+            }
         } else {
             //nothing to do
         }


### PR DESCRIPTION
Modified connection workflow so the host transmits a play status message to
connecting guests.  Guests then set the currentEntry member of PlaylistService
and dispatch a play or paused intent to notify the rest of the system.

Refactored PlaybarFragment to listen only to the intents from playlist service
(not the messages), and pull current song data from the playlist.

Refactored RemoteAudioPlayer to listen to intents from the playlist service
(instead of messages) and update the internal state accordingly.

Fixed a bug where the focus changed listener was being left registered when we
recreated an AudioPlayerWithEvents object, leading to weird play/pause behavior.

NOTE: This also seems to have addressed the issue of showing the "now playing" icon on the guest.

fixes #164 
fixes #180 
fixes #176 
fixes #169
