### PR TITLE
Guest lock screen controls

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/SoundStreamExternalControlClient.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/SoundStreamExternalControlClient.java
@@ -43,7 +43,7 @@ import com.lastcrusade.soundstream.util.RemoteControlClientCompat;
  *  Registering the MEDIA_BUTTON handler
  *  Registering a RemoteControlClient object (for lock screen remote control on ICS +)
  * 
- * @author thejenix
+ * @author Jesse Rosalia
  *
  */
 public class SoundStreamExternalControlClient {
@@ -112,7 +112,7 @@ public class SoundStreamExternalControlClient {
                     setPlaying();
                 }
             })
-            .addLocalAction(PlaylistService.ACTION_SONG_PLAYING, new IBroadcastActionHandler() {
+            .addLocalAction(PlaylistService.ACTION_CURRENT_SONG, new IBroadcastActionHandler() {
                 
                 @Override
                 public void onReceiveAction(Context context, Intent intent) {

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/AudioPlayerWithEvents.java
@@ -110,6 +110,18 @@ public class AudioPlayerWithEvents implements IPlayer {
         }
     }
 
+    /**
+     * A public method to request audio focus.  This is
+     * used on the guest, when they receive a message
+     * that a song is playing (vs actually pressing play
+     * on the device).
+     * 
+     * NOTE: this is a bandaid that will be fixed after
+     * beta is launched.
+     */
+    public void requestAudioFocus() {
+    	requestAudio();
+    }
 
     /**
      * Called from the AudioFocusChangeListener to handle the different stages

--- a/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/audio/SingleFileAudioPlayer.java
@@ -103,7 +103,7 @@ public class SingleFileAudioPlayer implements IPlayer, IDuckable {
     private void setEntryAndNotify(PlaylistEntry entry) {
         this.entry = entry;
         //This is sending a playlist entry not a SongMetadata
-        new LocalBroadcastIntent(PlaylistService.ACTION_SONG_PLAYING)
+        new LocalBroadcastIntent(PlaylistService.ACTION_CURRENT_SONG)
             .putExtra(PlaylistService.EXTRA_SONG, this.entry)
             .send(this.context);
     }


### PR DESCRIPTION
Fixes #172 by requesting audio focus on the guest on PlayStatusMessage, and ensuring the external control client has the current song when we receive that message.
