### PR TITLE
For Host only, set disconnect/disband to disband only

### DIFF
--- a/SoundStream/res/values/strings.xml
+++ b/SoundStream/res/values/strings.xml
@@ -63,7 +63,7 @@
 
     <string name="no_songs_in_playlist">There are no songs in your playlist! Quick, go add some from the music library!</string>
     <string name="disband">Disband</string>
-    <string name="dialog_disband">Are you sure you want to disband? This will boot all connected users.</string>
+    <string name="dialog_disband">Are you sure you want to disband? This will boot any connected users.</string>
 
     <string name="searching">Searching...</string>
     <!-- default values -->

--- a/SoundStream/src/com/lastcrusade/soundstream/components/NetworkFragment.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/components/NetworkFragment.java
@@ -149,17 +149,16 @@ public class NetworkFragment extends SherlockFragment implements ITitleable {
     }
 
     private void setDisconnectDisbandBtn() {
-		// The only time a host should be connected is if we are a guest. In
-		// this case, it should be a disband function, otherwise (when we are
-		// host) it should be be a disconnect function.
-		if (getConnectionService() == null
-				|| getConnectionService().isHostConnected()) {
-			setDisconnectFunction();
-    	} else {
-    		setDisbandFunction();
-    	}
+        // The only time a host should be connected is if we are a guest. In
+        // this case, it should be a disband function, otherwise (when we are
+        // host) it should be be a disconnect function.
+        if (getConnectionService() == null || getConnectionService().isHostConnected()) {
+            setDisconnectFunction();
+        } else {
+            setDisbandFunction();
+        }
     }
-    
+
     private void setDisconnectFunction(){
         ((TextView)disconnectDisband.findViewById(R.id.disconnect_disband_label))
             .setText(R.string.disconnect);

--- a/SoundStream/src/com/lastcrusade/soundstream/components/NetworkFragment.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/components/NetworkFragment.java
@@ -34,7 +34,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -150,17 +149,15 @@ public class NetworkFragment extends SherlockFragment implements ITitleable {
     }
 
     private void setDisconnectDisbandBtn() {
-        //if there is a guest connected, then we are the host and we want the button
-        //to function as a disband button
-        if (getConnectionService() != null && getConnectionService().isGuestConnected()) {
-            if(disconnectDisband != null){
-                setDisbandFunction();
-            }
-        } else{
-            if(disconnectDisband != null){
-                setDisconnectFunction();
-            }
-        } 
+		// The only time a host should be connected is if we are a guest. In
+		// this case, it should be a disband function, otherwise (when we are
+		// host) it should be be a disconnect function.
+		if (getConnectionService() == null
+				|| getConnectionService().isHostConnected()) {
+			setDisconnectFunction();
+    	} else {
+    		setDisbandFunction();
+    	}
     }
     
     private void setDisconnectFunction(){


### PR DESCRIPTION
Change the functionality of the disconnect/diaband
button in the network fragment to serve as disband
at all times when you are host, and disconnect at
all times when you are guest.

Fixes #184
Fixes #183 by changing disband confirmation wording
