### PR TITLE
copy guest list into a separate arraylist, to avoid concurrent modification exception

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/service/ConnectionService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/ConnectionService.java
@@ -419,7 +419,12 @@ public class ConnectionService extends Service {
     }
 
     public void disconnectAllGuests() {
-        for (MessageThread thread : this.guests) {
+        //copy the contents into separate array...the cancel/disconnect procedure
+        // will remove each thread from the guests array, and this will avoid
+        // a ConcurrentModificationException
+        List<MessageThread> toCancel = new ArrayList<MessageThread>(this.guests);
+        Log.d(TAG, String.format("Disconnecting %d guests...", toCancel.size()));
+        for (MessageThread thread : toCancel) {
             thread.cancel();
         }
     }


### PR DESCRIPTION
the onDisconnect method removes each canceled thread from the guest list.  By copying the list before iteration here, it avoids concurrent modifications on that list.  At the end, the guest list should be clear through repeated calls to onDisconnect because all threads should be canceled.

Fixes #238 
