### PR TITLE
State when paused

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/components/PlaylistFragment.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/components/PlaylistFragment.java
@@ -184,6 +184,16 @@ public class PlaylistFragment extends MusicListFragment{
                 //place to do so
             }
         })
+        .addLocalAction(PlaylistService.ACTION_CURRENT_SONG, new IBroadcastActionHandler() {
+
+			@Override
+			public void onReceiveAction(Context context, Intent intent) {
+				//the current song has changed...notify the adapter that we must
+				// rerender the rows
+				mPlayListAdapter.notifyDataSetChanged();
+			}
+        	
+        })
         .register(this.getActivity());
     }
 


### PR DESCRIPTION
Fixed issues with skipping/removing when paused by ensuring that any "set next song call" effectively will cause the player to play from the beginning of whatever song is set.

Fixed issue with synchronization between host and guest by sending playStatusMessage when host sets a new song.

Fixes #234
Fixes #244
Fixes #248
