### PR TITLE
Guest music list

### DIFF
--- a/SoundStream/src/com/lastcrusade/soundstream/model/User.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/model/User.java
@@ -60,7 +60,7 @@ public class User {
     @Override
     public boolean equals(Object obj){
         boolean result;
-        if (obj == null) {
+        if ((obj == null) || !(obj instanceof User)) {
             result = false;
         } else {
             User other = (User) obj;

--- a/SoundStream/src/com/lastcrusade/soundstream/model/User.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/model/User.java
@@ -57,11 +57,13 @@ public class User {
 
     }
 
-    public boolean equals(User other){
+    @Override
+    public boolean equals(Object obj){
         boolean result;
-        if (other == null) {
+        if (obj == null) {
             result = false;
         } else {
+            User other = (User) obj;
             result = macAddress.equals(other.getMacAddress()) && bluetoothID.equals(other.getBluetoothID());
         }
         return result;

--- a/SoundStream/src/com/lastcrusade/soundstream/model/User.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/model/User.java
@@ -55,5 +55,15 @@ public class User {
         }
         return macAddress;
 
-    }  
+    }
+
+    public boolean equals(User other){
+        boolean result;
+        if (other == null) {
+            result = false;
+        } else {
+            result = macAddress.equals(other.getMacAddress()) && bluetoothID.equals(other.getBluetoothID());
+        }
+        return result;
+    }
 }

--- a/SoundStream/src/com/lastcrusade/soundstream/model/UserList.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/model/UserList.java
@@ -35,6 +35,7 @@ public class UserList implements Parcelable{
 
     
     public static final String ACTION_USER_LIST_UPDATE = UserList.class.getName() + ".action.UserList";
+    public static final String EXTRA_REMOVED_USERS = UserList.class.getName() + "extra.RemovedUsers";
 
     private List<User> connectedUsers;    
     private UserColors userColors;

--- a/SoundStream/src/com/lastcrusade/soundstream/service/MusicLibraryService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/MusicLibraryService.java
@@ -40,6 +40,7 @@ import com.lastcrusade.soundstream.R;
 import com.lastcrusade.soundstream.library.MediaStoreWrapper;
 import com.lastcrusade.soundstream.library.SongNotFoundException;
 import com.lastcrusade.soundstream.model.SongMetadata;
+import com.lastcrusade.soundstream.model.UserList;
 import com.lastcrusade.soundstream.service.MessagingService.MessagingServiceBinder;
 import com.lastcrusade.soundstream.service.ServiceLocator.IOnBindListener;
 import com.lastcrusade.soundstream.util.AlphabeticalComparator;
@@ -157,11 +158,24 @@ public class MusicLibraryService extends Service {
                     }
                 }
             })
+            .addLocalAction(UserList.ACTION_USER_LIST_UPDATE, new IBroadcastActionHandler() {
+
+                @Override
+                public void onReceiveAction(Context context, Intent intent) {
+                    UserList removedUsers = (UserList) intent.getParcelableExtra(UserList.EXTRA_REMOVED_USERS);
+                    if(removedUsers != null) {
+                        for(String mac : removedUsers.getMacAddresses()){
+                            removeLibraryForAddress(mac, true);
+                        }
+                    }
+                }
+            })
             .addLocalAction(ConnectionService.ACTION_GUEST_DISCONNECTED, new IBroadcastActionHandler() {
 
                 @Override
                 public void onReceiveAction(Context context, Intent intent) {
                     String macAddress = intent.getStringExtra(ConnectionService.EXTRA_GUEST_ADDRESS);
+                    Log.w(TAG, macAddress +" disconnected");
                     removeLibraryForAddress(macAddress, true);
                 }
             })

--- a/SoundStream/src/com/lastcrusade/soundstream/service/MusicLibraryService.java
+++ b/SoundStream/src/com/lastcrusade/soundstream/service/MusicLibraryService.java
@@ -162,6 +162,10 @@ public class MusicLibraryService extends Service {
 
                 @Override
                 public void onReceiveAction(Context context, Intent intent) {
+                    /*
+                     *  When we get a updated user list message we calculate the users that were removed.
+                     *  Here we loop through the removed users and remove any songs that belong to disconnected users.
+                    */
                     UserList removedUsers = (UserList) intent.getParcelableExtra(UserList.EXTRA_REMOVED_USERS);
                     if(removedUsers != null) {
                         for(String mac : removedUsers.getMacAddresses()){


### PR DESCRIPTION
Fixes #237

Basically what is happening is when we update the playlist it is an update not a replace so the removed songs don't get removed. 
The way we fixed this was when we get a updated user list message we calculate the users that were removed and include them in the userlist updated intent. In music library service we loop through the removed users and remove any songs that are their's.
