### PR TITLE
Instructions are no longer one single page of text

### DIFF
--- a/SoundStream/res/layout/fragment_about.xml
+++ b/SoundStream/res/layout/fragment_about.xml
@@ -26,6 +26,47 @@
 	    android:layout_height="wrap_content"
 	    android:orientation="vertical"
 	    >
+	    <!-- Instructions -->
+	    <RelativeLayout
+	        android:id="@+id/instructions"
+	        android:layout_width="match_parent"
+	        android:layout_height="wrap_content"
+	        android:layout_margin="10dp" 
+	        >
+	
+	
+	        <TextView 
+	            android:id="@+id/instructions_label"
+	            android:layout_width="wrap_content"
+	            android:layout_height="wrap_content"
+	            android:text="@string/instructions_label"
+	            android:textSize="18sp"
+	            
+	            />
+	        
+	        <View
+	            android:id="@+id/instructions_line"
+	            android:layout_width="fill_parent"
+	            android:layout_height="2dp"
+	            android:layout_marginTop="3dp"
+	            android:layout_marginBottom="10dp"
+	            android:layout_below="@id/instructions_label"
+	            android:background="@color/accent_blue" 
+	            />
+	
+	        <TextView 
+	            android:id="@+id/instructions_text"
+	            android:layout_width="wrap_content"
+	            android:layout_height="wrap_content"
+	            android:layout_below="@id/instructions_line"
+	            android:layout_marginLeft="10dp"
+	            android:textSize="16sp"
+	            android:textColor="@color/link_blue"
+	            android:text="@string/instructions"
+	            />
+	        
+	    </RelativeLayout>
+	
 	
 	    <!-- Meet the Crusaders -->
 	    <RelativeLayout

--- a/SoundStream/res/values/strings.xml
+++ b/SoundStream/res/values/strings.xml
@@ -90,5 +90,10 @@
     <string name="credit_label">Credit</string>
     <string name="brought_to_you_by">SoundStream is built on top of the following fine open source projects:</string>
 
-    <string name="welcome">Welcome to SoundStream!\n\nCreate a new network by pressing Create, or join an existing network by pressing Join and asking a friend to let you in.\n\nAdd music to your playlist through the Music page.\n\nIf there is no music there, check out the SoundStream wiki for information on how to add music to your phone.\n\nGo to the Network page to add people to your network.</string>
+    <string name="welcome">Welcome to SoundStream!\n\nFor some basic instructions and hints, press Next.</string>
+	<string name="welcome_connection">Create a new network by pressing Create, or join an existing network by pressing Join and asking a friend to let you in.</string>
+	<string name="welcome_music">Add music to your playlist through the Music page.\n\nIf there is no music there, check out the SoundStream wiki for information on how to add music to your phone.</string>
+	<string name="welcome_network">To view information about the network, go the the network page.\n\n From there you can add members to the network, disconnect, or switch networks. </string>
+	<string name="instructions_label">Instructions</string>
+	<string name="instructions">View the startup instructions again</string>
 </resources>

--- a/SoundStream/res/values/strings.xml
+++ b/SoundStream/res/values/strings.xml
@@ -92,8 +92,8 @@
 
     <string name="welcome">Welcome to SoundStream!\n\nFor some basic instructions and hints, press Next.</string>
 	<string name="welcome_connection">Create a new network by pressing Create, or join an existing network by pressing Join and asking a friend to let you in.</string>
-	<string name="welcome_music">Add music to your playlist through the Music page.\n\nIf there is no music there, check out the SoundStream wiki for information on how to add music to your phone.</string>
-	<string name="welcome_network">To view information about the network, go the the network page.\n\n From there you can add members to the network, disconnect, or switch networks. </string>
+	<string name="welcome_music">Add music to your playlist through the Music Library page.\n\nIf there is no music there, check out the SoundStream wiki for information on how to add music to your phone.</string>
+	<string name="welcome_network">To view information about the network, go the the Network page.\n\n From there you can add members to the network, disconnect, or switch networks. </string>
 	<string name="instructions_label">Instructions</string>
 	<string name="instructions">View the startup instructions again</string>
 </resources>

--- a/SoundStream/src/com/thelastcrusade/soundstream/CoreActivity.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/CoreActivity.java
@@ -38,6 +38,7 @@ import com.google.analytics.tracking.android.EasyTracker;
 import com.google.analytics.tracking.android.GoogleAnalytics;
 import com.google.analytics.tracking.android.Tracker;
 import com.thelastcrusade.soundstream.components.ConnectFragment;
+import com.thelastcrusade.soundstream.components.InstructionsDialog;
 import com.thelastcrusade.soundstream.components.MenuFragment;
 import com.thelastcrusade.soundstream.components.PlaybarFragment;
 import com.thelastcrusade.soundstream.model.SongMetadata;
@@ -129,16 +130,8 @@ public class CoreActivity extends SlidingFragmentActivity implements Trackable {
             
             prefs.edit().putBoolean("firstrun", false).commit();
 
-            new AlertDialog.Builder(this)
-                .setMessage(R.string.welcome)
-                .setPositiveButton("Ok",
-                    new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog,int which) {
-                            //do nothing
-                        }
-                     }).show();
+            new InstructionsDialog(this).show();
         }
-
     }
 
 

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/AboutFragment.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/AboutFragment.java
@@ -23,6 +23,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.TextView;
@@ -64,6 +65,15 @@ public class AboutFragment extends SherlockFragment implements ITitleable {
 				emailIntent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.email_subject_tag));
 				startActivity(Intent.createChooser(emailIntent, "Send email..."));
 			}
+        });
+        
+        v.findViewById(R.id.instructions_text).setOnClickListener(new OnClickListener() {
+            
+            @Override
+            public void onClick(View v) {
+                new InstructionsDialog(getActivity()).show();
+                
+            }
         });
 
         return v;

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/InstructionsDialog.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/InstructionsDialog.java
@@ -32,24 +32,26 @@ public class InstructionsDialog {
     private Activity activity;
     private static final int[] MESSAGEIDS = {R.string.welcome, R.string.welcome_connection, 
             R.string.welcome_music, R.string.welcome_network };
+    private static final int WELCOME_INDEX = 0;
     
     public InstructionsDialog(Activity activity){
         this.activity = activity;
     }
     public void show(){
-        showInstructions(0);
+        showInstructions(WELCOME_INDEX);
     }
     
     private void showInstructions(final int messageIndex){
         String positiveString = messageIndex < MESSAGEIDS.length-1?  "Next" : "Done";
-        String negativeString = messageIndex > 0 ?  "Back" : "Skip";
+        String negativeString = messageIndex > WELCOME_INDEX ?  "Back" : "Skip";
         
         new AlertDialog.Builder(activity)
             .setMessage(MESSAGEIDS[messageIndex])
             .setPositiveButton(positiveString,
             new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog,int which) {
-                    if(messageIndex < MESSAGEIDS.length-1){
+                    //as long as we haven't hit the last message, we should move to the next one
+                    if(messageIndex < MESSAGEIDS.length-1){ 
                         showInstructions(messageIndex+1);    
                     }
                 }
@@ -58,7 +60,7 @@ public class InstructionsDialog {
             
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                if(messageIndex > 0 ){
+                if(messageIndex > WELCOME_INDEX ){
                     showInstructions(messageIndex-1);    
                 }  
             }

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/InstructionsDialog.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/InstructionsDialog.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013 The Last Crusade ContactLastCrusade@gmail.com
+ * 
+ * This file is part of SoundStream.
+ * 
+ * SoundStream is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * SoundStream is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with SoundStream.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.thelastcrusade.soundstream.components;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import com.thelastcrusade.soundstream.R;
+
+/**
+ * @author Elizabeth
+ *
+ */
+public class InstructionsDialog {
+    private Activity activity;
+    private static final int[] MESSAGEIDS = {R.string.welcome, R.string.welcome_connection, 
+            R.string.welcome_music, R.string.welcome_network };
+    
+    public InstructionsDialog(Activity activity){
+        this.activity = activity;
+    }
+    public void show(){
+        showInstructions(0);
+    }
+    
+    private void showInstructions(final int messageIndex){
+        String positiveString = messageIndex < MESSAGEIDS.length-1?  "Next" : "Done";
+        String negativeString = messageIndex > 0 ?  "Back" : "Skip";
+        
+        new AlertDialog.Builder(activity)
+            .setMessage(MESSAGEIDS[messageIndex])
+            .setPositiveButton(positiveString,
+            new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog,int which) {
+                    if(messageIndex < MESSAGEIDS.length-1){
+                        showInstructions(messageIndex+1);    
+                    }
+                }
+             })
+        .setNegativeButton(negativeString, new DialogInterface.OnClickListener() {
+            
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if(messageIndex > 0 ){
+                    showInstructions(messageIndex-1);    
+                }  
+            }
+        }).show();
+    }
+
+}


### PR DESCRIPTION
broke up the single instructions dialog into multiple consecutive dialogs and allowed the user to access them again via the about page.

In the future I want to change this to the nice multi-page dialogs that some apps use (does anyone know how they do this? I couldn't find much about it when I was looking) with colors and icons and things
