### PR TITLE
implemented changes to ask the user before enabling bluetooth.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ grail-diary/*
 
 # Ignore third party libraries added as well
 third_party/
+
+# Nuisance files
+.DS_Store

--- a/SoundStream/res/values/strings.xml
+++ b/SoundStream/res/values/strings.xml
@@ -24,7 +24,10 @@
     <string name="app_name">Sound Stream</string>
     <string name="app_name_no_spaces">SoundStream</string>
     
-    <string name="enable_bluetooth">Enabling Bluetooth&#x2026;</string>
+    <string name="enable">Enable</string>
+    <string name="enable_bluetooth">Enable Bluetooth&#x2026;</string>
+    <string name="ask_enable_bluetooth">SoundStream needs to enable Bluetooth to continue.  Press Enable to enable Bluetooth.</string>
+    <string name="enabling_bluetooth">Enabling Bluetooth&#x2026;</string>
     <string name="finding_new_guests">Finding new guests&#x2026;</string>
     <string name="found_guests">Found guests</string>
     <string name="select_guests">Select guests&#x2026;</string>

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/ConnectFragment.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/ConnectFragment.java
@@ -116,7 +116,13 @@ public class ConnectFragment extends SherlockFragment implements ITitleable{
 
             @Override
             public void onClick(View v) {
-                getConnectionService().broadcastSelfAsGuest(getActivity());
+                new WithBluetoothEnabled(getActivity(), getConnectionService()).run(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        getConnectionService().broadcastSelfAsGuest(getActivity());
+                    }
+                });
             }
         });
         joinView.setContentDescription(ContentDescriptionUtils.CONNECT);

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/MusicLibraryFragment.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/MusicLibraryFragment.java
@@ -267,6 +267,7 @@ public class MusicLibraryFragment extends MusicListFragment {
                 @Override
                 public void onClick(View v) {
                     SongMetadata meta = getItem((Integer) v.getTag());
+                    Log.d(TAG, "Adding " + meta + " to playlist");
                     getPlaylistService().addSong(meta);
                     
                     //change the color of the view for a small period of time to indicate that the add 

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/WithBluetoothEnabled.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/WithBluetoothEnabled.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013 The Last Crusade ContactLastCrusade@gmail.com
+ * 
+ * This file is part of SoundStream.
+ * 
+ * SoundStream is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * SoundStream is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with SoundStream.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.thelastcrusade.soundstream.components;
+
+import android.app.AlertDialog;
+import android.app.AlertDialog.Builder;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Handler;
+import android.util.Log;
+
+import com.thelastcrusade.soundstream.R;
+import com.thelastcrusade.soundstream.service.ConnectionService;
+
+/**
+ * A simple wrapper class to run code with bluetooth enabled.  This class will ask for permission
+ * to enable bluetooth if it is not already enabled, enable bluetooth if needed, and then run the
+ * suppled code in the same thread as the caller.  It will only ask for permission if bluetooth
+ * needs to be enabled; if it is already enabled, the code is run straight away.
+ * 
+ * NOTE: Currently, this does not disable bluetooth after the code is run, and does not attempt
+ * to enable bluetooth multiple times or cycle bluetooth on and off.  It is therefore safe to
+ * wrap around any code that requires bluetooth to be enabled.
+ * 
+ * If we want to implement functionality to allow us to cycle bluetooth on, run code, and then
+ * turn it off, we can do so by creating an internal runnable that runs the supplied code, then
+ * disables the bluetooth adapter.
+ * 
+ * @author Jesse Rosalia
+ *
+ */
+public class WithBluetoothEnabled {
+
+    private static String TAG = WithBluetoothEnabled.class.getSimpleName();
+    private Context context;
+    private ConnectionService connectionService;
+    /**
+     * 
+     */
+    public WithBluetoothEnabled(Context context, ConnectionService connectionService) {
+        this.context = context;
+        this.connectionService = connectionService;
+    }
+
+    /**
+     * Note: must be called from a thread with an established Looper (e.g. main UI thread).
+     * The supplied runnable will be run in that thread.
+     * 
+     * @param runnable
+     */
+    public void run(final Runnable runnable) {
+        final Handler handler = new Handler();
+        if (!connectionService.isNetworkEnabled()) {
+            Builder builder = new AlertDialog.Builder(context);
+            builder.setTitle(R.string.enable_bluetooth)
+                   .setMessage(R.string.ask_enable_bluetooth)
+                   .setPositiveButton(R.string.enable, new DialogInterface.OnClickListener() {
+                    
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (connectionService.enableNetwork()) {
+                                handler.post(runnable);
+                            } else {
+                                Log.wtf(TAG, "Error enabling bluetooth");
+                            }
+                        }
+                    })
+                   .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            //NO OP
+                        }
+                    })
+                    .show();
+        } else {
+            handler.post(runnable);
+        }
+    }
+}

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/WithBluetoothEnabled.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/WithBluetoothEnabled.java
@@ -81,6 +81,8 @@ public class WithBluetoothEnabled {
                             }
                         }
                     })
+                    //NOTE: even though this is a NO OP, it is required to show a cancel button
+                    // (as seen on a Nexus 4 running Jelly Bean)
                    .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
 
                         @Override

--- a/SoundStream/src/com/thelastcrusade/soundstream/net/BluetoothDiscoveryHandler.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/net/BluetoothDiscoveryHandler.java
@@ -20,14 +20,12 @@
 package com.thelastcrusade.soundstream.net;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.util.Log;
 
-import com.thelastcrusade.soundstream.R;
 import com.thelastcrusade.soundstream.model.FoundGuest;
 import com.thelastcrusade.soundstream.service.ConnectionService;
 import com.thelastcrusade.soundstream.util.LocalBroadcastIntent;
@@ -50,9 +48,18 @@ public class BluetoothDiscoveryHandler {
 
     private boolean remoteInitiated;
 
+    private boolean discoveryStarted;
+
     public BluetoothDiscoveryHandler(Context context, BluetoothAdapter adapter) {
         this.context = context;
         this.adapter = adapter;
+    }
+
+    /**
+     * @return
+     */
+    public boolean isDiscoveryStarted() {
+        return this.discoveryStarted;
     }
 
     /**
@@ -61,6 +68,7 @@ public class BluetoothDiscoveryHandler {
      */
     public void onDiscoveryStarted(boolean remoteInitiated) {
         Log.w(TAG, "Discovery started");
+        this.discoveryStarted = true;
         this.remoteInitiated = remoteInitiated;
         this.discoveredGuests = new ArrayList<FoundGuest>();
     }
@@ -78,6 +86,10 @@ public class BluetoothDiscoveryHandler {
         new LocalBroadcastIntent(action)
             .putParcelableArrayListExtra(ConnectionService.EXTRA_GUESTS, this.discoveredGuests)
             .send(this.context);
+        
+        //reinit the handler, for the next time
+        this.discoveredGuests = new ArrayList<FoundGuest>();
+        this.discoveryStarted = false;
     }
 
     /**

--- a/SoundStream/src/com/thelastcrusade/soundstream/util/BluetoothUtils.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/util/BluetoothUtils.java
@@ -41,11 +41,10 @@ public class BluetoothUtils {
     /* The maximum number of seconds to put the device in discoverable mode */
     private static final int DISCOVERABLE_SECONDS = 30;
 
-
     public static void checkAndEnableBluetooth(Context context, BluetoothAdapter adapter) throws BluetoothNotEnabledException, BluetoothNotSupportedException {
         if (adapter != null) {
             if (!adapter.isEnabled()) {
-                Toaster.iToast(context, R.string.enable_bluetooth);
+                Toaster.iToast(context, R.string.enabling_bluetooth);
                 //start the adapter
                 boolean enableStarted = adapter.enable();
                 boolean enabled = false;


### PR DESCRIPTION
removed auto enable of bluetooth from ConnectionService onCreate

added wrapper class to ask the user, enable bluetooth, and then run supplied
code

implemented use of wrapper on "Join" button (connectfragment), "Add users"
button, and "Switch networks" button (networkfragment)

Fixes #298 
Fixes #294 
Fixes #293 
