### PR TITLE
Fixed NPE and other issues caused by delaying bluetooth enable

### DIFF
--- a/SoundStream/src/com/thelastcrusade/soundstream/service/ConnectionService.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/service/ConnectionService.java
@@ -88,6 +88,10 @@ public class ConnectionService extends Service {
     public static final String ACTION_HOST_CONNECTED       = ConnectionService.class.getName() + ".action.HostConnected";
     public static final String ACTION_HOST_DISCONNECTED    = ConnectionService.class.getName() + ".action.HostDisconnected";
 
+    public static final String ACTION_ADAPTER_ENABLED      = ConnectionService.class.getName() + ".action.AdapterEnabled";
+    public static final String EXTRA_MY_NAME               = ConnectionService.class.getName() + ".extra.MyName";
+    public static final String EXTRA_MY_ADDRESS            = ConnectionService.class.getName() + ".extra.MyAddress";
+
     /**
      * Class for clients to access.  Because we know this service always
      * runs in the same process as its clients, we don't need to deal with
@@ -117,7 +121,7 @@ public class ConnectionService extends Service {
         super.onCreate();
         
         this.adapter = BluetoothAdapter.getDefaultAdapter();
-        Log.d(TAG, "MAC Address: " + this.adapter.getAddress());
+        Log.d(TAG, "MAC Address: " + BluetoothUtils.getLocalBluetoothMAC());
 
         registerReceivers();
         
@@ -577,6 +581,14 @@ public class ConnectionService extends Service {
         boolean bluetoothEnabled = false;
         try {
             BluetoothUtils.checkAndEnableBluetooth(this, adapter);
+            //broadcast that the adapter has been enabled.  this may be watched
+            // by the user list or other components that expect a bluetooth
+            // mac address in order to make sure the held address is correct
+            new LocalBroadcastIntent(ConnectionService.ACTION_ADAPTER_ENABLED)
+                .putExtra(EXTRA_MY_ADDRESS, BluetoothUtils.getLocalBluetoothMAC())
+                .putExtra(EXTRA_MY_NAME,    BluetoothUtils.getLocalBluetoothName())
+                .send(this);
+
             bluetoothEnabled = true;
         } catch (BluetoothNotEnabledException e) {
             Toaster.iToast(this.getBaseContext(),

--- a/SoundStream/src/com/thelastcrusade/soundstream/service/UserListService.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/service/UserListService.java
@@ -28,9 +28,9 @@ import android.util.Log;
 import com.thelastcrusade.soundstream.model.User;
 import com.thelastcrusade.soundstream.model.UserList;
 import com.thelastcrusade.soundstream.util.BluetoothUtils;
-import com.thelastcrusade.soundstream.util.LocalBroadcastIntent;
 import com.thelastcrusade.soundstream.util.BroadcastRegistrar;
 import com.thelastcrusade.soundstream.util.IBroadcastActionHandler;
+import com.thelastcrusade.soundstream.util.LocalBroadcastIntent;
 
 public class UserListService extends Service {
     private static final String TAG = UserListService.class.getSimpleName();
@@ -89,6 +89,15 @@ public class UserListService extends Service {
                 String macAddress  = intent.getStringExtra(ConnectionService.EXTRA_GUEST_ADDRESS);
                 curUserList.addUser(bluetoothID, macAddress);
                 notifyUserListUpdate();
+            }
+        })
+        .addLocalAction(ConnectionService.ACTION_ADAPTER_ENABLED, new IBroadcastActionHandler() {
+
+            @Override
+            public void onReceiveAction(Context context, Intent intent) {
+                myName = intent.getStringExtra(ConnectionService.EXTRA_MY_NAME);
+                myMac  = intent.getStringExtra(ConnectionService.EXTRA_MY_ADDRESS);
+                clearExternalUsers(); //clear the list and reload "self"
             }
         })
         .addLocalAction(ConnectionService.ACTION_GUEST_DISCONNECTED, new IBroadcastActionHandler() {

--- a/SoundStream/src/com/thelastcrusade/soundstream/util/BluetoothUtils.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/util/BluetoothUtils.java
@@ -95,7 +95,8 @@ public class BluetoothUtils {
         if(mBluetoothAdapter!=null) {
             name = mBluetoothAdapter.getName();
             if(name == null){
-                name = mBluetoothAdapter.getAddress();
+                Log.wtf(TAG, "Name is null...using MAC address");
+                name = getLocalBluetoothMAC();
             }
         }
         else{


### PR DESCRIPTION
due to the following problem:

On certain devices, the bluetooth name and address are null if BT is not enabled.  We had methods to handle this, but the method that safeguarded the name relied on the provided getAddress method, not our safe method.  Additionally, once bluetooth is enabled, we need to make sure we update our internal structures that rely on it.

Fix #314 
