### PR TITLE
Filter initiating guest out of discovery results

### DIFF
--- a/SoundStream/src/com/thelastcrusade/soundstream/net/BluetoothDiscoveryHandler.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/net/BluetoothDiscoveryHandler.java
@@ -46,7 +46,7 @@ public class BluetoothDiscoveryHandler {
 
     private ArrayList<FoundGuest> discoveredGuests;
 
-    private boolean remoteInitiated;
+    private String remoteInitiatorAddress;
 
     private boolean discoveryStarted;
 
@@ -66,10 +66,10 @@ public class BluetoothDiscoveryHandler {
      * Call to indicate the start of discovery.  This MUST be called before devices are discovered.
      * 
      */
-    public void onDiscoveryStarted(boolean remoteInitiated) {
+    public void onDiscoveryStarted(String remoteInitiator) {
         Log.w(TAG, "Discovery started");
         this.discoveryStarted = true;
-        this.remoteInitiated = remoteInitiated;
+        this.remoteInitiatorAddress = remoteInitiator;
         this.discoveredGuests = new ArrayList<FoundGuest>();
     }
 
@@ -80,7 +80,7 @@ public class BluetoothDiscoveryHandler {
     public void onDiscoveryFinished() {
         Log.w(TAG, "Discovery finished");
         //if its remote initiated, we want to send a different action
-        String action = this.remoteInitiated
+        String action = this.remoteInitiatorAddress != null
                           ? ConnectionService.ACTION_REMOTE_FIND_FINISHED
                           : ConnectionService.ACTION_FIND_FINISHED;
         new LocalBroadcastIntent(action)
@@ -110,7 +110,10 @@ public class BluetoothDiscoveryHandler {
                 device = adapter.getRemoteDevice(bonded.getAddress());
             }
         }
-
-        this.discoveredGuests.add(new FoundGuest(device.getName(), device.getAddress(), known));
+        //only add the remote if they were not the initiator
+        //NOTE: handles null check inside equals
+        if (!device.getAddress().equals(this.remoteInitiatorAddress)) {
+            this.discoveredGuests.add(new FoundGuest(device.getName(), device.getAddress(), known));
+        }
     }
 }

--- a/SoundStream/src/com/thelastcrusade/soundstream/service/ConnectionService.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/service/ConnectionService.java
@@ -110,7 +110,7 @@ public class ConnectionService extends Service {
     private ServiceLocator<MessagingService> messagingServiceLocator;
     private BluetoothDiscoveryHandler        bluetoothDiscoveryHandler;
 
-    private MessageThread discoveryInitiator;
+    private String discoveryInitiatorAddress;
 
     private BroadcastRegistrar broadcastRegistrar;
 
@@ -244,7 +244,7 @@ public class ConnectionService extends Service {
                     //if this has already been called, don't call it again (see below
                     // ...this is to handle any weird race conditions)
                     if (!bluetoothDiscoveryHandler.isDiscoveryStarted()) {
-                        bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiator != null);
+                        bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiatorAddress);
                     }
                 }
             })
@@ -255,10 +255,11 @@ public class ConnectionService extends Service {
                     //NOTE: if we start discovery immediately after enabling bluetooth,
                     // we MAY not get the ACTION_DISCOVERY_STARTED intent...in that case,
                     // "fake it" by calling onDiscoveryStarted, so that our internal
-                    // member variables are set up.  this will only happen if no guests
-                    // are found, but we want to be internally consistent.
+                    // member variables are set up.
+                    // NOTE: this specific case will only happen if no guests are found,
+                    // but we want to be internally consistent.
                     if (!bluetoothDiscoveryHandler.isDiscoveryStarted()) {
-                        bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiator != null);
+                        bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiatorAddress);
                     }
                     bluetoothDiscoveryHandler.onDiscoveryFinished();
                 }
@@ -272,7 +273,7 @@ public class ConnectionService extends Service {
                     // "fake it" by calling onDiscoveryStarted, so that our internal
                     // member variables are set up to record a found guest
                     if (!bluetoothDiscoveryHandler.isDiscoveryStarted()) {
-                        bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiator != null);
+                        bluetoothDiscoveryHandler.onDiscoveryStarted(discoveryInitiatorAddress);
                     }
                     bluetoothDiscoveryHandler.onDiscoveryFound(
                             (BluetoothDevice) intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE));
@@ -286,12 +287,17 @@ public class ConnectionService extends Service {
                     List<FoundGuest> foundGuests = intent.getParcelableArrayListExtra(ConnectionService.EXTRA_GUESTS);
                     FoundGuestsMessage msg = new FoundGuestsMessage(foundGuests);
                     try {
-                        discoveryInitiator.write(msg);
+                        MessageThread initiatorGuest = findMessageThreadByAddress(discoveryInitiatorAddress);
+                        if (initiatorGuest != null) {
+                            initiatorGuest.write(msg);
+                        } else {
+                            Log.wtf(TAG, "Find finished, but guest is not found: " + discoveryInitiatorAddress);
+                        }
                     } catch (IOException e) {
                         Log.wtf(TAG, e);
                         Toaster.eToast(ConnectionService.this, "Unable to enqueue message " + msg.getClass().getSimpleName());
                     }
-                    discoveryInitiator = null; //clear the initiator to handle the next one
+                    discoveryInitiatorAddress = null; //clear the initiator to handle the next one
                 }
             })
            .register(this);
@@ -310,15 +316,14 @@ public class ConnectionService extends Service {
     private void handleFindNewGuestsMessage(final String remoteAddr) {
         Toaster.iToast(this, R.string.finding_new_guests);
 
-        MessageThread found = findMessageThreadByAddress(remoteAddr);
-
-        if (found == null) {
-            Log.wtf(TAG, "Unknown remote device: " + remoteAddr);
+        //sanity check to make sure the guest is still connected before we go
+        if (findMessageThreadByAddress(remoteAddr) != null) {
+            this.discoveryInitiatorAddress = remoteAddr;
+            findNewGuests();
+        } else {
+            Log.wtf(TAG, "Find New Guests message recieved from unknown remote device: " + remoteAddr);
             return;
         }
-
-        this.discoveryInitiator = found;
-        findNewGuests();
     }
 
     /**


### PR DESCRIPTION
Fixes #199.  The ConnectionService keeps track of the address of the initiator, and passes that to the BluetoothDiscoveryHandler which will filter out any discoveries of that address

Full testing TBD (waiting for a device to charge)
