### PR TITLE
Remove the last bits of ABS from the source

### DIFF
--- a/SoundStream/res/layout/fragment_about.xml
+++ b/SoundStream/res/layout/fragment_about.xml
@@ -246,7 +246,6 @@
                android:layout_width="wrap_content"
                android:layout_height="wrap_content"
                android:layout_marginLeft="10dp"
-               android:text="@string/thanks_ABS"
                android:textColor="@color/link_blue"
                android:layout_below="@id/brought_to_you_by"
                android:textSize="16sp"

--- a/SoundStream/res/menu/search_menu.xml
+++ b/SoundStream/res/menu/search_menu.xml
@@ -3,7 +3,7 @@
     <item 
         android:id="@+id/search" 
         android:showAsAction="always|collapseActionView"
-        android:actionViewClass="com.actionbarsherlock.widget.SearchView"
+        android:actionViewClass="android.widget.SearchView"
         android:icon="@android:drawable/ic_menu_search"
     />
 </menu>

--- a/SoundStream/res/values/strings.xml
+++ b/SoundStream/res/values/strings.xml
@@ -80,14 +80,12 @@
     <string name="meet_label">Meet the Team</string>
     <string name="team">Reid Baker\nDavid Greenhalgh\nElizabeth Johnson\nJesse Rosalia\nTaylor Wrobel</string>
     <string name="thanks_label">Special Thanks</string>
-    <string name="thanks_ABS"><u>ActionBarSherlock</u></string>
     <string name="thanks_SlidingMenu"><u>SlidingMenu</u></string>
     <string name="thanks_Troy">Troy Peace - a super sponsor, without whom none of this would be possible</string>
     <string name="contact_us_label">Contact Us</string>
     <string name="repo_link_text"><u>Our GitHub repo</u></string>
     <string name="repo_link">https://github.com/TheLastCrusade/SoundStream</string>
     <string name="sliding_menu_link">https://github.com/jfeinstein10/SlidingMenu</string>
-    <string name="ABS_link">https://github.com/JakeWharton/ActionBarSherlock</string>
     <string name="beta_help_instructions">SoundStream is currently in beta, so if you run into an issue, email us at:</string>
     <string name="email_link_text"><u>SoundStreamHelp@gmail.com</u></string>
     <string name="email_support_address">SoundStreamHelp@gmail.com</string>

--- a/SoundStream/src/com/thelastcrusade/soundstream/components/AboutFragment.java
+++ b/SoundStream/src/com/thelastcrusade/soundstream/components/AboutFragment.java
@@ -48,12 +48,10 @@ public class AboutFragment extends Fragment implements ITitleable {
         final TextView 
         	repoLinkText = (TextView)v.findViewById(R.id.repo_link),
         	SlidingMenuLinkText = (TextView)v.findViewById(R.id.thanks_SlidingMenu),
-        	ABSLinkText = (TextView)v.findViewById(R.id.thanks_ABS),
         	emailLinkText = (TextView)v.findViewById(R.id.email_link);
         
         listenToHttpLink(repoLinkText, getString(R.string.repo_link));
         listenToHttpLink(SlidingMenuLinkText, getString(R.string.sliding_menu_link));
-        listenToHttpLink(ABSLinkText, getString(R.string.ABS_link));
         
         emailLinkText.setOnClickListener(new AdapterView.OnClickListener() {
 


### PR DESCRIPTION
Reid missed a few instances of ABS that caused the
app to crash when running (despite compiling).  This
fix removes references to ABS from the XML files, and
from the About fragment.
